### PR TITLE
Add twisty menu system & checksum instructions

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -18,6 +18,9 @@
           <pre><code>cd &lt;path/to/your/directory&gt;</code></pre>
         </li>
         <li>
+          Optional: use the <a href="#sha256">checksum instructions</a> below to ensure the authenticity of your binary.
+        </li>
+        <li>
           Extract the <code>tar.gz</code>. You can use the following command:
           <pre><code>tar -xf &lt;filename&gt;.tar.gz</code></pre>
         </li>
@@ -41,6 +44,9 @@
           <pre><code>cd &lt;path\to\your\directory&gt;</code></pre>
         </li>
         <li>
+          Optional: use the <a href="#sha256">checksum instructions</a> below to ensure the authenticity of your binary.
+        </li>
+        <li>
           Extract the <code>.zip</code>. You can use the following command:
           <pre><code>unzip &lt;filename&gt;.zip</code></pre>
         </li>
@@ -53,6 +59,26 @@
           <pre><code>java -version</code></pre>
         </li>
       </ol>
+    </div>
+
+    <div>
+      <h2 id="sha256" class="bold">Checking the SHA-256 checksum</h2>
+      <p>Optionally, you can compare the SHA-256 checksum of your downloaded binary against the checksums that are provided for every release and nightly build.</p>
+      <p>Follow the instructions for your platform to generate a SHA-256 checksum of your downloaded binary, then open the corresponding <code>.txt</code> checksum file and ensure that it contains the same number.</p>
+      <ul>
+        <li>
+          <span>Linux: </span>
+          <pre><code>sha256sum path/to/file.tar.gz</code></pre>
+        </li>
+        <li>
+          <span>macOS: </span>
+          <pre><code>shasum -a 256 path/to/file.tar.gz</code></pre>
+        </li>
+        <li>
+          <span>Windows: </span>
+          <pre><code>certutil -hashfile path/to/file.zip SHA256</code></pre>
+        </li>
+      </ul>
     </div>
 
   </div>

--- a/src/handlebars/partials/menu.handlebars
+++ b/src/handlebars/partials/menu.handlebars
@@ -3,16 +3,22 @@
       <i id="menu-close" class="fa fa-arrow-circle-left" aria-hidden="true"></i>
   </div>
   <div id="menu-content">
-      <p><a href="./index.html">Home</a></p>
-      <p><a href="./releases.html">Latest release</a></p>
-      <p><a href="./archive.html">Release archive</a></p>
-      <p><a href="./nightly.html">Nightly builds</a></p>
-      <p><a href="./installation.html">Installation</a></p>
-      <p><a href="./getinvolved.html">Get involved</a></p>
-      <p><a href="./support.html">Support</a></p>
-      <p><a href="./sponsors.html">Sponsors</a></p>
-      <p><a href="./about.html">About</a></p>
-      <p><a target="_blank" href="http://api.adoptopenjdk.net">API</a></p>
-      <div class="align-center"><div id="menu-social-bar">{{> social-bar }}</div></div>
+    <ul>
+      <li><a href="./index.html">Home</a></li>
+      <li><a href="./releases.html">Latest release</a></li>
+      <li><a href="./archive.html">Release archive</a></li>
+      <li><a href="./nightly.html">Nightly builds</a></li>
+      <li><a href="./installation.html">Installation</a></li>
+      <li><a target="_blank" href="http://api.adoptopenjdk.net">API</a></li>
+      <li class="submenu"><a>Further information</a>
+        <ul>
+          <li><a href="./getinvolved.html">Get involved</a></li>
+          <li><a href="./support.html">Support</a></li>
+          <li><a href="./sponsors.html">Sponsors</a></li>
+          <li><a href="./about.html">About</a></li>
+        </ul>
+      </li>
+    </ul>
+    <div class="align-center"><div id="menu-social-bar">{{> social-bar }}</div></div>
   </div>
 </div>

--- a/src/js/0-global.js
+++ b/src/js/0-global.js
@@ -181,3 +181,20 @@ function msieversion() {
     }
     else { return false; }
 }
+
+// build the menu twisties
+var submenus = document.getElementById("menu-content").getElementsByClassName("submenu");
+
+for (i = 0; i < submenus.length; i++) {
+  var twisty = document.createElement("span");
+  var twistyContent = document.createTextNode(">");
+  twisty.appendChild(twistyContent);
+  twisty.className = "twisty";
+
+  var thisLine = submenus[i].getElementsByTagName('a')[0];
+  thisLine.appendChild(twisty);
+
+  thisLine.onclick = function(){
+    this.parentNode.classList.toggle("open");
+  }
+}

--- a/src/scss/styles-1-large-main.scss
+++ b/src/scss/styles-1-large-main.scss
@@ -256,16 +256,49 @@ nav {
   padding: .8rem 0;
 }
 
-#menu-content p {
+#menu-content ul {
+  margin: 0;
+  padding: 0;
+}
+
+#menu-content li {
   border-bottom: 1px solid $accentgrey;
   margin: 0;
   line-height: 1.2rem;
+  list-style: none;
+}
+
+#menu-content .submenu > a > .twisty {
+  transition-duration: .3s;
+  margin-right: 0.5rem;
+  float: left;
+}
+
+#menu-content .submenu > ul {
+  display: none;
+}
+
+#menu-content .submenu > ul > li {
+  padding-left: 1rem;
+  font-size: 0.9rem;
+  line-height: 0.9rem;
+  border-top: 1px solid $accentgrey;
+  border-bottom: none;
+  background-color: rgba(255,255,255,.4);
+}
+
+#menu-content .submenu.open > ul {
+  display: initial;
+}
+
+#menu-content .submenu.open > a > .twisty {
+  transform: rotate(90deg);
 }
 
 #menu-social-bar {
   display: inline-block;
   filter: brightness(0);
-  margin: 1rem auto 3rem;
+  margin: 1rem auto;
 }
 
 


### PR DESCRIPTION
https://staging.adoptopenjdk.net/

**NOTE FOR STAGING: Once again, the staging server has used a cached version of the CSS, so the menu is looking pretty strange at the moment.**

You can now add nested accordion-style submenus (with an unlimited number of sub-sub-menus) by adding the following simple `<li>` element structure instead of the standard single line:

**Standard menu entry:**
```
<li><a href="">Menu item 1</a></li>
```
**Nested submenu entry:** 
```
<li class="submenu"><a>Submenu parent</a>
    <ul>
        <li><a href="">Submenu child item 1</a></li>
        <li><a href="">Submenu child item 2</a></li>
    </ul>
</li>
```

> **Important:** the submenu parent `<li>` must have the class `submenu`

Also updated the Installation page to include checksum instructions for Linux, Mac, Windows