### PR TITLE
Change arm64 > aarch64, add Windows platform

### DIFF
--- a/src/js/0-global.js
+++ b/src/js/0-global.js
@@ -36,23 +36,23 @@ var platforms = [
     osDetectionString: "not-to-be-detected"
   },
   {
-    officialName: "Linux arm64",
-    searchableName: "ARM64_LINUX",
+    officialName: "Linux aarch64",
+    searchableName: "AARCH64_LINUX",
     logo: "arm.png",
     fileExtension: ".tar.gz",
     requirements: "GLIBC 2.5 and above",
     architecture: "64",
     osDetectionString: "not-to-be-detected"
   },
-  /*{
+  {
     officialName: "Windows x86-64",
-    searchableName: "WIN",
+    searchableName: "X64_WIN",
     logo: "windows.png",
     fileExtension: ".zip",
     requirements: "VS 2010 and above",
     architecture: "64",
     osDetectionString: "Windows Win Cygwin"
-  }*/
+  },
   {
     officialName: "macOS x86-64",
     searchableName: "X64_MAC",


### PR DESCRIPTION
On [staging](https://staging.adoptopenjdk.net) (currently waiting on cache to clear for updates to be visible)

Naming and search of arm64 changed to aarch64.

Windows platform added in anticipation of the new builds.
However, Windows will not actually appear on the site until the builds are added.