### PR TITLE
Add more OS detection options for Windows

### DIFF
--- a/src/js/0-global.js
+++ b/src/js/0-global.js
@@ -24,7 +24,7 @@ var platforms = [
     binaryExtension: ".zip",
     installerExtension: ".exe",
     architecture: "64",
-    osDetectionString: "Windows Win Cygwin"
+    osDetectionString: "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP"
   },
   {
     officialName: "macOS x64",


### PR DESCRIPTION
Addition to a string only, has no impact on existing functionality.

Required the additions to recognise some Windows-based OSes.