### PR TITLE
Add hashes to minified JS and CSS files, add BrowserSync (Fixes #108)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
-dist/js/app.min.js
+dist/js/app.min*.js
 src/js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
     npm install
     ```
 
-3. Start the auto-build scripts, and leave them running
+3. Start the auto-build scripts and BrowserSync (opens a new `localhost:3000` browser tab). Leave this process running during development.
 
     ```
     npm start
@@ -22,7 +22,9 @@
 
     > NOTE: These build scripts enable you to view your changes locally. The build generates new files in two places: a new `/dist` directory (JS, CSS, images, etc), and `.html` files in the root directory. However, these files are ignored by .gitignore, and will not be included in commits.
 
-4. Make changes in the `/src` directory. The auto-build scripts instantly pick up any newly saved changes, and include them in the output files and directories. Open `/index.html` in any browser to view the website locally, and refresh the page after saving your changes to `/src`.
+4. Make changes in the `/src` directory. Every time you save a file, the script instantly picks up any new changes and displays them in your BrowserSync-connected window.
+
+    > PRO TIP: Look in the Terminal/Command window immediately after you run `npm start`. BrowserSync provides 'Local' and 'External' Access URLs to view your latest changes live. If you have a phone or tablet connected to the same WiFi network, you can use the mobile browser to access the 'External' URL and view your latest changes in real-time. This makes it very easy to test your changes on different devices during development.
 
 ---
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 const gulp = require('gulp');
 const runSequence = require('run-sequence');
 
+const browserSync = require('browser-sync').create();
 const concat = require('gulp-concat');
 const cssmin = require('gulp-minify-css');
 const rename = require('gulp-rename');
@@ -12,21 +13,31 @@ const handlebars = require('gulp-compile-handlebars');
 const eslint = require('gulp-eslint');
 const gutil = require('gulp-util');
 const sitemap = require('gulp-sitemap');
+const hash = require('gulp-hash');
+const inject = require('gulp-inject');
 //const robots = require('gulp-robots');
 
 // default task
-gulp.task('default', ['handlebars','scripts','styles','images','icon','watch']);
+gulp.task('default', function() {
+  runSequence(['handlebars','scripts','styles','images','icon'],'inject','watch','browser-sync');
+});
 
 // build task
 gulp.task('build', function() {
-  runSequence(['handlebars','scripts','styles','images','icon'],'sitemap','lint');
+  runSequence(['handlebars','scripts','styles','images','icon'],'inject','sitemap','lint');
 });
 
 // watch task
 gulp.task('watch', function() {
-  gulp.watch(['./src/handlebars/partials/*.handlebars', './src/handlebars/*.handlebars'], ['handlebars']);
-  gulp.watch('./src/js/*.js', ['scripts']);
-  gulp.watch('./src/scss/*.scss', ['styles']);
+  gulp.watch(['./src/handlebars/partials/*.handlebars', './src/handlebars/*.handlebars'], function() {
+    runSequence('handlebars','inject', browserSync.reload);
+  });
+  gulp.watch('./src/js/*.js', function() {
+    runSequence('scripts','inject', browserSync.reload);
+  });
+  gulp.watch('./src/scss/*.scss', function() {
+    runSequence('styles','inject', browserSync.reload);
+  });
   gulp.watch(['./src/assets/*.jp*', './src/assets/*.png', './src/assets/*.gif'], ['images']);
   gulp.watch('./src/assets/*.ico', ['icon']);
 });
@@ -39,6 +50,7 @@ gulp.task('handlebars', function () {
       ignorePartials: true, // ignores unknown partials in the template, defaults to false
       batch : ['./src/handlebars/partials']
   }
+
   return gulp.src('./src/handlebars/*.handlebars')
       .pipe(handlebars(templateData, options))
       .on('error', gutil.log)
@@ -60,7 +72,15 @@ gulp.task('scripts', function() {
     .pipe(rename({
       suffix: '.min'
     }))
-    .pipe(gulp.dest('./dist/js/'));
+    .pipe(hash()) // Add hashes to the files' names
+    .on('error', gutil.log)
+    .pipe(gulp.dest('./dist/js/'))
+    .pipe(hash.manifest('assetsJS.json', {
+      deleteOld: true,
+      sourceDir: __dirname + '/dist/js'
+    })) // Switch to the manifest file
+    .on('error', gutil.log)
+    .pipe(gulp.dest('./dist/')); // Write the manifest file
 });
 
 // styles task
@@ -78,7 +98,24 @@ gulp.task('styles', function() {
     .pipe(rename({
       suffix: '.min'
     }))
+    .pipe(hash()) // Add hashes to the files' names
+    .on('error', gutil.log)
     .pipe(gulp.dest('./dist/css/'))
+    .pipe(hash.manifest('assetsCSS.json', {
+      deleteOld: true,
+      sourceDir: __dirname + '/dist/css'
+    })) // Switch to the manifest file
+    .on('error', gutil.log)
+    .pipe(gulp.dest('./dist/')); // Write the manifest file
+});
+
+// inject task
+gulp.task('inject', function() {
+  var sourceFiles = gulp.src(['./dist/js/app.min-*.js', './dist/css/styles.min-*.css'], {read: false}, {relative: true});
+  var targetFiles = gulp.src('./*.html');
+
+  return targetFiles.pipe(inject(sourceFiles)) // injects the latest minified JS and CSS into all HTML files
+  .pipe(gulp.dest('./'));
 });
 
 // images task
@@ -86,13 +123,13 @@ gulp.task('images', function() {
   return gulp.src(['./src/assets/*.jp*', './src/assets/*.png', './src/assets/*.gif'])
     .pipe(imagemin())
     .on('error', gutil.log)
-    .pipe(gulp.dest('./dist/assets/'))
+    .pipe(gulp.dest('./dist/assets/'));
 });
 
 // icon task
 gulp.task('icon', function() {
   return gulp.src('./src/assets/*.ico')
-    .pipe(gulp.dest('./dist/assets/'))
+    .pipe(gulp.dest('./dist/assets/'));
 });
 
 // lint task
@@ -112,6 +149,16 @@ gulp.task('sitemap', function () {
       siteUrl: 'https://adoptopenjdk.net'
     }))
     .pipe(gulp.dest('./'));
+});
+
+// browser-sync task
+gulp.task('browser-sync', function() {
+    browserSync.init({
+        server: {
+            baseDir: "./"
+        },
+        notify: false
+    });
 });
 
 // robots task - commented out unless required.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "author": "Joe Brady",
   "devDependencies": {
+    "browser-sync": "^2.18.12",
     "chai": "^3.5.0",
     "eslint": "^3.19.0",
     "gulp": "^3.9.1",
@@ -18,7 +19,9 @@
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-concat": "^2.6.1",
     "gulp-eslint": "^3.0.1",
+    "gulp-hash": "^4.1.1",
     "gulp-imagemin": "^3.2.0",
+    "gulp-inject": "^4.2.0",
     "gulp-minify-css": "^1.2.4",
     "gulp-rename": "^1.2.2",
     "gulp-robots": "^2.0.4",

--- a/src/handlebars/partials/footer.handlebars
+++ b/src/handlebars/partials/footer.handlebars
@@ -38,7 +38,8 @@
 
 </footer>
 
-<script src="dist/js/app.min.js"></script>
+<!-- inject:js -->
+<!-- endinject -->
 {{{script}}}
 {{{script2}}}
 {{{script3}}}

--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -9,7 +9,8 @@
     <link rel="shortcut icon" href="dist/assets/favicon.ico" type="image/x-icon">
     <link rel="icon" href="dist/assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
-    <link rel="stylesheet" href="dist/css/styles.min.css">
+    <!-- inject:css -->
+    <!-- endinject -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
     {{{style1}}}


### PR DESCRIPTION
[STAGING](https://staging.adoptopenjdk.net)

Hashes are now automatically added to the filename of minified CSS and JS.
Links to these hashed files are then automatically injected into every HTML file, so there is no action needed on the part of the developer.

Browser-sync is also added, for instant automatic browser refreshes whenever a file in `/src` is saved.
Browser-sync also allows for easy testing on mobile devices, as explained in the new "PRO TIP" on Contributing.md.