### PR TITLE
Fix Gulp hashing issue

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,15 +16,22 @@ const sitemap = require('gulp-sitemap');
 const hash = require('gulp-hash');
 const inject = require('gulp-inject');
 const robots = require('gulp-robots');
+const clean = require('gulp-clean');
 
 // default task
 gulp.task('default', function() {
-  runSequence(['handlebars','scripts','styles','images','icon'],'inject','watch','browser-sync');
+  runSequence('clean',['handlebars','scripts','styles','images','icon'],'inject','watch','browser-sync');
 });
 
 // build task
 gulp.task('build', function() {
-  runSequence(['handlebars','scripts','styles','images','icon'],'inject','sitemap','robots','lint');
+  runSequence('clean',['handlebars','scripts','styles','images','icon'],'inject','sitemap','robots','lint');
+});
+
+// clean task (deletes /dist dir)
+gulp.task('clean', function () {
+  return gulp.src('dist', {read: false})
+    .pipe(clean());
 });
 
 // watch task
@@ -47,17 +54,17 @@ gulp.task('handlebars', function () {
   var templateData = {
   },
   options = {
-      ignorePartials: true, // ignores unknown partials in the template, defaults to false
-      batch : ['./src/handlebars/partials']
+    ignorePartials: true, // ignores unknown partials in the template, defaults to false
+    batch : ['./src/handlebars/partials']
   }
 
   return gulp.src('./src/handlebars/*.handlebars')
-      .pipe(handlebars(templateData, options))
-      .on('error', gutil.log)
-      .pipe(rename({
-        extname: '.html'
-      }))
-      .pipe(gulp.dest('./'));
+    .pipe(handlebars(templateData, options))
+    .on('error', gutil.log)
+    .pipe(rename({
+      extname: '.html'
+    }))
+    .pipe(gulp.dest('./'));
 });
 
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-babel": "^6.1.2",
+    "gulp-clean": "^0.3.2",
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-concat": "^2.6.1",
     "gulp-eslint": "^3.0.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)

Fixed duplicate hashed file issue (which only occurred when you stopped the gulp service, made changes, then restarted the gulp service - thus bypassing the hash tracking process temporarily), and prevented any similar issues in the future, by adding `gulp-clean`. This destroys the existing `/dist` directory every time the main gulp process is started, meaning that the rest of the build can start from a clean sheet.