### PR TITLE
WIP: Add dynamic installation page

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,9 +12,6 @@ globals:
   detectOS: true
   loadJSON: true
   errorContainer: true
-  onIndexLoad: true
-  onNightlyLoad: true
-  onReleasesLoad: true
   getSearchableName: true
   getOfficialName: true
   getBinaryExt: true
@@ -29,5 +26,10 @@ globals:
   setTickLink: true
   loadPlatformsThenData: true
   variant: true
+  platformSelector: true
+  hljs: true
+  getInstallCommand: true
+  getChecksumCommand: true
+  getPathCommand: true
 
 extends: eslint:recommended

--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -20,7 +20,7 @@
               <h2 class="bold"><var platform>\{{thisOfficialName}}</var> installation</h2>
               <ol>
                 <li>
-                  Make sure you have downloaded the latest <a href="\{{thisBinaryLink}}"><var platform>\{{thisOfficialName}}</var> binary</a> to a directory that will not move or be deleted, and use Terminal/Command Prompt to <code>cd</code> into it.
+                  Make sure you have downloaded the latest <strong><a href="\{{thisBinaryLink}}"><var platform>\{{thisOfficialName}}</var> binary</a></strong> to a directory that will not move or be deleted, and use Terminal/Command Prompt to <code>cd</code> into it.
                 </li>
                 <li>
                   Optional: use the checksum instructions below to ensure the authenticity of your binary.

--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -1,90 +1,57 @@
-{{> header title='Installation | ' style1='<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/railscasts.min.css">' style2='<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>' }}
+{{> header title='Installation | ' style1='<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/obsidian.min.css">' style2='<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>' }}
 
 <main class="grey-bg">
 
-  <h1 class="margin-bottom large-title">Installation</h1>
+  <h1 class="large-title">Installation</h1>
 
-  <!--<h3>Jump to:</h3>
-  <h3 class="zero-margin inline-block"><a class="grey-button no-underline" href="#linux-mac">Linux and macOS</a></h3>
-  <h3 class="zero-margin inline-block"><a class="grey-button no-underline" href="#windows">Windows</a></h3>-->
+  <div id="loading"><img src="dist/assets/loading_dots.gif" width="40" height="40"></div>
+  <div id="error-container"></div>
 
-  <div class="info-page-container">
-    <div class="margin-bottom">
-      <h2 id="linux-mac" class="bold">Linux, AIX and macOS installation</h2>
-      <ol>
-        <li>Download the latest <code>tar.gz</code> from the <a href="./releases.html">Latest build</a> page to a directory that will not move or be deleted.</li>
-        <li>
-          Using Terminal, navigate to the location of this <code>tar.gz</code>:
-          <pre><code>cd &lt;path/to/your/directory&gt;</code></pre>
-        </li>
-        <li>
-          Optional: use the <a href="#sha256">checksum instructions</a> below to ensure the authenticity of your binary.
-        </li>
-        <li>
-          Extract the <code>tar.gz</code>. You can use the following command:
-          <pre><code>tar -xf &lt;filename&gt;.tar.gz</code></pre>
-          Note: for <strong>AIX</strong>, use the following command:
-          <pre><code>gunzip -c &lt;filename&gt;.tar.gz | tar xf -</code></pre>
-        </li>
-        <li>
-          Add this version of Java to your PATH:
-          <pre><code>export PATH=$PWD/j2sdk-image/bin:$PATH</code></pre>
-        </li>
-        <li>
-          Check that Java has installed correctly:
-          <pre><code>java -version</code></pre>
-        </li>
-      </ol>
+  <div id="installation-container" class="info-page-container hide">
+    <div class="align-center">
+      <select id="variant-selector"></select>
+      <h2 class="inline-block">Platform: </h2><select id="platform-selector" style="margin-left:1rem;"></select>
     </div>
+    <div id="installation-template">
+      <script id="template" type="text/x-handlebars-template">
+        \{{#each htmlTemplate}}
+          <div id="installation-container-\{{thisPlatform}}" class="installation-single-platform hide">
+            <div class="margin-bottom">
+              <h2 class="bold"><var platform>\{{thisOfficialName}}</var> installation</h2>
+              <ol>
+                <li>
+                  Make sure you have downloaded the latest <a href="\{{thisBinaryLink}}"><var platform>\{{thisOfficialName}}</var> binary</a> to a directory that will not move or be deleted, and use Terminal/Command Prompt to <code>cd</code> into it.
+                </li>
+                <li>
+                  Optional: use the checksum instructions below to ensure the authenticity of your binary.
+                </li>
+                <li>
+                  Extract the <code><var extension>\{{thisBinaryExtension}}</var></code>. You can use the following command:
+                  <pre><code><var unzipCommand>\{{thisInstallCommand}}</var></code></pre>
+                </li>
+                <li>
+                  Add this version of Java to your PATH:
+                  <pre><code><var pathCommand>\{{thisPathCommand}}</var></code></pre>
+                </li>
+                <li>
+                  Check that Java has installed correctly:
+                  <pre><code>java -version</code></pre>
+                </li>
+              </ol>
+            </div>
 
-    <div class="margin-bottom">
-      <h2 id="windows" class="bold">Windows installation</h2>
-      <ol>
-        <li>Download the latest <code>.zip</code> from the <a href="./releases.html">Latest build</a> page to a directory that will not move or be deleted.</li>
-        <li>
-          Using the command prompt, navigate to the location of this <code>.zip</code>:
-          <pre><code>cd &lt;path\to\your\directory&gt;</code></pre>
-        </li>
-        <li>
-          Optional: use the <a href="#sha256">checksum instructions</a> below to ensure the authenticity of your binary.
-        </li>
-        <li>
-          Extract the <code>.zip</code>. You can use the following command:
-          <pre><code>unzip &lt;filename&gt;.zip</code></pre>
-        </li>
-        <li>
-          Add this version of Java to your PATH:
-          <pre><code>set PATH=%cd%\j2sdk-image\bin;%PATH%</code></pre>
-        </li>
-        <li>
-          Check that Java has installed correctly:
-          <pre><code>java -version</code></pre>
-        </li>
-      </ol>
+            <div>
+              <h2 class="bold">Checking the SHA-256 checksum</h2>
+              <p>Optionally, you can compare the SHA-256 checksum of your downloaded binary against the checksums that are provided for every release and nightly build.</p>
+              <p>Use this command to generate a SHA-256 checksum of your downloaded binary, then open the corresponding <a href="\{{thisChecksumLink}}">checksum file</a> and ensure that it contains the same number.</p>
+              <pre><code><var checksumCommand>\{{thisChecksumCommand}}</var></code></pre>
+            </div>
+          </div>
+        \{{/each}}
+      </script>
     </div>
-
-    <div>
-      <h2 id="sha256" class="bold">Checking the SHA-256 checksum</h2>
-      <p>Optionally, you can compare the SHA-256 checksum of your downloaded binary against the checksums that are provided for every release and nightly build.</p>
-      <p>Follow the instructions for your platform to generate a SHA-256 checksum of your downloaded binary, then open the corresponding <code>.txt</code> checksum file and ensure that it contains the same number.</p>
-      <ul>
-        <li>
-          <span>Linux: </span>
-          <pre><code>sha256sum path/to/file.tar.gz</code></pre>
-        </li>
-        <li>
-          <span>macOS & AIX: </span>
-          <pre><code>shasum -a 256 path/to/file.tar.gz</code></pre>
-        </li>
-        <li>
-          <span>Windows: </span>
-          <pre><code>certutil -hashfile path/to/file.zip SHA256</code></pre>
-        </li>
-      </ul>
-    </div>
-
   </div>
 
 </main>
 
-{{> footer script='<script>hljs.initHighlightingOnLoad();</script>'}}
+{{> footer script='<script src="https://cdnjs.cloudflare.com/ajax/libs/platform/1.3.4/platform.min.js"></script>' script2='<script>onInstallationLoad();</script>' }}

--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -27,15 +27,15 @@
                 </li>
                 <li>
                   Extract the <code><var extension>\{{thisBinaryExtension}}</var></code>. You can use the following command:
-                  <pre><code><var unzipCommand>\{{thisInstallCommand}}</var></code></pre>
+                  <pre><code><var id="unzip-\{{thisPlatform}}" unzipCommand>\{{thisUnzipCommand}}</var></code><span onclick="copyClipboard('#unzip-\{{thisPlatform}}')" class="copy-code-button">Copy</span></pre>
                 </li>
                 <li>
                   Add this version of Java to your PATH:
-                  <pre><code><var pathCommand>\{{thisPathCommand}}</var></code></pre>
+                  <pre><code><var id="path-\{{thisPlatform}}" pathCommand>\{{thisPathCommand}}</var></code><span onclick="copyClipboard('#path-\{{thisPlatform}}')" class="copy-code-button">Copy</span></pre>
                 </li>
                 <li>
                   Check that Java has installed correctly:
-                  <pre><code>java -version</code></pre>
+                  <pre><code id="java-\{{thisPlatform}}">java -version</code><span onclick="copyClipboard('#java-\{{thisPlatform}}')" class="copy-code-button">Copy</span></pre>
                 </li>
               </ol>
             </div>
@@ -44,7 +44,7 @@
               <h2 class="bold">Checking the SHA-256 checksum</h2>
               <p>Optionally, you can compare the SHA-256 checksum of your downloaded binary against the checksums that are provided for every release and nightly build.</p>
               <p>Use this command to generate a SHA-256 checksum of your downloaded binary, then open the corresponding <a href="\{{thisChecksumLink}}">checksum file</a> and ensure that it contains the same number.</p>
-              <pre><code><var checksumCommand>\{{thisChecksumCommand}}</var></code></pre>
+              <pre><code><var id="checksum-\{{thisPlatform}}" checksumCommand>\{{thisChecksumCommand}}</var></code><span onclick="copyClipboard('#checksum-\{{thisPlatform}}')" class="copy-code-button">Copy</span></pre>
             </div>
           </div>
         \{{/each}}
@@ -54,4 +54,4 @@
 
 </main>
 
-{{> footer script='<script src="https://cdnjs.cloudflare.com/ajax/libs/platform/1.3.4/platform.min.js"></script>' script2='<script>onInstallationLoad();</script>' }}
+{{> footer script='<script src="https://cdnjs.cloudflare.com/ajax/libs/platform/1.3.4/platform.min.js"></script>' script2='<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>' script3='<script>onInstallationLoad();</script>' }}

--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -1,4 +1,4 @@
-{{> header title='Installation | ' style1='<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/obsidian.min.css">' style2='<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>' }}
+{{> header title='Installation | ' style1='<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/obsidian.min.css">' }}
 
 <main class="grey-bg">
 
@@ -54,4 +54,4 @@
 
 </main>
 
-{{> footer script='<script src="https://cdnjs.cloudflare.com/ajax/libs/platform/1.3.4/platform.min.js"></script>' script2='<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>' script3='<script>onInstallationLoad();</script>' }}
+{{> footer script='<script src="https://cdnjs.cloudflare.com/ajax/libs/platform/1.3.4/platform.min.js"></script>' script2='<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>' script3='<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>' script4='<script>onInstallationLoad();</script>' }}

--- a/src/js/0-global.js
+++ b/src/js/0-global.js
@@ -261,3 +261,12 @@ function setVariantSelector() {
     };
   }
 }
+
+function copyClipboard(element) {
+  var $temp = $('<input>');
+  $('body').append($temp);
+  $temp.val($(element).text()).select();
+  document.execCommand('copy');
+  $temp.remove();
+  alert('Copied to clipboard');
+}

--- a/src/js/0-global.js
+++ b/src/js/0-global.js
@@ -5,6 +5,7 @@ var lookup = {};
 var i = 0;
 var variant = getQueryByName('variant');
 var variantSelector = document.getElementById('variant-selector');
+var platformSelector = document.getElementById('platform-selector');
 
 function setLookup() {
   // FUNCTIONS FOR GETTING PLATFORM DATA
@@ -71,6 +72,21 @@ function getInstallerExt(searchableName) {
 // gets the LOGO WITH PATH when you pass in 'searchableName'
 function getLogo(searchableName) {
   return (logoPath + (lookup[searchableName].logo));
+}
+
+// gets the INSTALLATION COMMAND when you pass in 'searchableName'
+function getInstallCommand(searchableName) {
+  return (lookup[searchableName].installCommand);
+}
+
+// gets the CHECKSUM COMMAND when you pass in 'searchableName'
+function getChecksumCommand(searchableName) {
+  return (lookup[searchableName].checksumCommand);
+}
+
+// gets the PATH COMMAND when you pass in 'searchableName'
+function getPathCommand(searchableName) {
+  return (lookup[searchableName].pathCommand);
 }
 
 // set value for loading dots on every page
@@ -215,31 +231,33 @@ function persistUrlQuery() {
 }
 
 function setVariantSelector() {
-  if(variantSelector.options.length === 0) {
-    variants.forEach(function(eachVariant) {
+  if(variantSelector) {
+    if(variantSelector.options.length === 0) {
+      variants.forEach(function(eachVariant) {
+        var op = new Option();
+        op.value = eachVariant.searchableName;
+        op.text = eachVariant.officialName;
+        variantSelector.options.add(op);
+      });
+    }
+
+    if(!variant) {
+      variant = variants[0].searchableName;
+    }
+
+    variantSelector.value = variant;
+
+    if(variantSelector.value === '') {
       var op = new Option();
-      op.value = eachVariant.searchableName;
-      op.text = eachVariant.officialName;
+      op.value = 'unknown';
+      op.text = 'Select a variant';
       variantSelector.options.add(op);
-    });
+      variantSelector.value = 'unknown';
+      errorContainer.innerHTML = '<p>Error: no such variant. Please select a valid variant from the drop-down list.</p>';
+    }
+
+    variantSelector.onchange = function() {
+      setUrlQuery('variant', variantSelector.value);
+    };
   }
-
-  if(!variant) {
-    variant = variants[0].searchableName;
-  }
-
-  variantSelector.value = variant;
-
-  if(variantSelector.value === '') {
-    var op = new Option();
-    op.value = 'unknown';
-    op.text = 'Select a variant';
-    variantSelector.options.add(op);
-    variantSelector.value = 'unknown';
-    errorContainer.innerHTML = '<p>Error: no such variant. Please select a valid variant from the drop-down list.</p>';
-  }
-
-  variantSelector.onchange = function() {
-    setUrlQuery('variant', variantSelector.value);
-  };
 }

--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -1,5 +1,6 @@
 var INSTALLDATA;
 
+/* eslint-disable no-unused-vars */
 function onInstallationLoad() {
   /* eslint-enable no-unused-vars */
 

--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -1,0 +1,155 @@
+var INSTALLDATA;
+
+function onInstallationLoad() {
+  /* eslint-enable no-unused-vars */
+
+  INSTALLDATA = new Object();
+  populateInstallation(); // populate the Latest page
+}
+
+function populateInstallation() {
+  loadPlatformsThenData(function() {
+
+    // TODO - the commented-out repoName variable below should be passed into loadJSON below as the first argument, replacing openjdk-releases.
+    // This can only be done after the repository name is updated from 'openjdk-releases' to 'openjdk8-releases'.
+
+    // var repoName = (variant + '-releases');
+
+    loadJSON('openjdk-releases', 'latest_release', function(response) {
+      var releasesJson = JSON.parse(response);
+      if (typeof releasesJson !== 'undefined') { // if there are releases...
+        buildInstallationHTML(releasesJson);
+      }
+      else {
+        // report an error
+        errorContainer.innerHTML = '<p>Error... no installation information has been found!</p>';
+        loading.innerHTML = ''; // remove the loading dots
+      }
+    });
+  });
+}
+
+function buildInstallationHTML(releasesJson) {
+
+  // create an array of the details for each asset that is attached to a release
+  var assetArray = [];
+  releasesJson.assets.forEach(function(each) {
+    assetArray.push(each);
+  });
+
+  var ASSETARRAY = [];
+
+  // for each asset attached to this release, check if it's a valid binary, then add a download block for it...
+  assetArray.forEach(function(eachAsset) {
+    var ASSETOBJECT = new Object();
+    var nameOfFile = (eachAsset.name);
+    var uppercaseFilename = nameOfFile.toUpperCase(); // make the name of the asset uppercase
+    ASSETOBJECT.thisPlatform = getSearchableName(uppercaseFilename); // get the searchableName, e.g. MAC or X64_LINUX.
+
+    // check if the platform name is recognised...
+    if(ASSETOBJECT.thisPlatform) {
+
+      ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
+      ASSETOBJECT.thisOfficialName = getOfficialName(ASSETOBJECT.thisPlatform);
+
+      // if the filename contains both the platform name and the matching BINARY extension, add the relevant info to the asset object
+      ASSETOBJECT.thisBinaryExtension = getBinaryExt(ASSETOBJECT.thisPlatform);
+      if(uppercaseFilename.indexOf(ASSETOBJECT.thisBinaryExtension.toUpperCase()) >= 0) {
+        ASSETOBJECT.thisPlatformExists = true;
+        ASSETOBJECT.thisBinaryLink = (eachAsset.browser_download_url);
+        ASSETOBJECT.thisBinaryFilename = (eachAsset.name);
+        ASSETOBJECT.thisChecksumLink = (eachAsset.browser_download_url).replace(ASSETOBJECT.thisBinaryExtension, '.sha256.txt');
+        ASSETOBJECT.thisChecksumFilename = (eachAsset.name).replace(ASSETOBJECT.thisBinaryExtension, '.sha256.txt');
+        ASSETOBJECT.thisInstallCommand = getInstallCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
+        ASSETOBJECT.thisChecksumCommand = getChecksumCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
+        ASSETOBJECT.thisPathCommand = getPathCommand(ASSETOBJECT.thisPlatform).replace('DIRNAME', releasesJson.name);
+      }
+
+      if(ASSETOBJECT.thisPlatformExists === true){
+        ASSETARRAY.push(ASSETOBJECT);
+      }
+
+    }
+  });
+
+  ASSETARRAY = orderPlatforms(ASSETARRAY);
+
+  INSTALLDATA.htmlTemplate = ASSETARRAY;
+
+  var template = Handlebars.compile(document.getElementById('template').innerHTML);
+  document.getElementById('installation-template').innerHTML = template(INSTALLDATA);
+
+  hljs.initHighlightingOnLoad();
+
+  setInstallationPlatformSelector(ASSETARRAY);
+  window.onhashchange = displayInstallPlatform;
+
+  loading.innerHTML = ''; // remove the loading dots
+  var installationContainer = document.getElementById('installation-container');
+  installationContainer.className = installationContainer.className.replace( /(?:^|\s)hide(?!\S)/g , ' animated fadeIn ' );
+}
+
+
+function displayInstallPlatform() {
+  var platformHash = window.location.hash.substr(1).toUpperCase();
+  var thisPlatformInstallation = document.getElementById('installation-container-' + platformHash);
+  unselectInstallPlatform();
+
+  if(thisPlatformInstallation) {
+    platformSelector.value = platformHash;
+    thisPlatformInstallation.classList.remove('hide');
+  }
+
+  else {
+    var currentValues = [];
+    var platformSelectorOptions = Array.apply(null, platformSelector.options);
+    platformSelectorOptions.forEach(function(eachOption) {
+      currentValues.push(eachOption.value);
+    });
+    if(currentValues.indexOf('unknown') === -1) {
+      var op = new Option();
+      op.value = 'unknown';
+      op.text = 'Select a platform';
+      platformSelector.options.add(op, 0);
+    }
+    platformSelector.value = 'unknown';
+  }
+}
+
+function unselectInstallPlatform() {
+  var platformInstallationDivs = document.getElementById('installation-container').getElementsByClassName('installation-single-platform');
+
+  for (i = 0; i < platformInstallationDivs.length; i++) {
+    platformInstallationDivs[i].classList.add('hide');
+  }
+}
+
+function setInstallationPlatformSelector(thisReleasePlatforms) {
+
+  if(platformSelector) {
+    if(platformSelector.options.length === 0) {
+      thisReleasePlatforms.forEach(function(eachPlatform) {
+        var op = new Option();
+        op.value = eachPlatform.thisPlatform;
+        op.text = eachPlatform.thisOfficialName;
+        platformSelector.options.add(op);
+      });
+    }
+
+    var OS = detectOS();
+    if(OS && window.location.hash.length < 1) {
+      platformSelector.value = OS.searchableName;
+      window.location.hash = platformSelector.value.toLowerCase();
+      displayInstallPlatform();
+    }
+    else {
+      displayInstallPlatform();
+    }
+
+    platformSelector.onchange = function() {
+      window.location.hash = platformSelector.value.toLowerCase();
+      displayInstallPlatform();
+    };
+
+  }
+}

--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -61,7 +61,7 @@ function buildInstallationHTML(releasesJson) {
         ASSETOBJECT.thisBinaryFilename = (eachAsset.name);
         ASSETOBJECT.thisChecksumLink = (eachAsset.browser_download_url).replace(ASSETOBJECT.thisBinaryExtension, '.sha256.txt');
         ASSETOBJECT.thisChecksumFilename = (eachAsset.name).replace(ASSETOBJECT.thisBinaryExtension, '.sha256.txt');
-        ASSETOBJECT.thisInstallCommand = getInstallCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
+        ASSETOBJECT.thisUnzipCommand = getInstallCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
         ASSETOBJECT.thisChecksumCommand = getChecksumCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
         ASSETOBJECT.thisPathCommand = getPathCommand(ASSETOBJECT.thisPlatform).replace('DIRNAME', releasesJson.name);
       }

--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -6,6 +6,10 @@ function onInstallationLoad() {
 
   INSTALLDATA = new Object();
   populateInstallation(); // populate the Latest page
+
+  $( document ).ready(function() {
+    hljs.initHighlightingOnLoad();
+  });
 }
 
 function populateInstallation() {
@@ -79,8 +83,6 @@ function buildInstallationHTML(releasesJson) {
 
   var template = Handlebars.compile(document.getElementById('template').innerHTML);
   document.getElementById('installation-template').innerHTML = template(INSTALLDATA);
-
-  hljs.initHighlightingOnLoad();
 
   setInstallationPlatformSelector(ASSETARRAY);
   window.onhashchange = displayInstallPlatform;

--- a/src/js/nightly.js
+++ b/src/js/nightly.js
@@ -13,6 +13,7 @@ var datepicker = document.getElementById('datepicker');
 function onNightlyLoad() {
   /* eslint-enable no-unused-vars */
   NIGHTLYDATA = new Object();
+
   setDatePicker();
   populateNightly(); // run the function to populate the table on the Nightly page.
 

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -101,13 +101,13 @@ function buildLatestHTML(releasesJson) {
 
   setTickLink();
 
+  displayLatestPlatform();
+  window.onhashchange = displayLatestPlatform;
+
   loading.innerHTML = ''; // remove the loading dots
 
   const latestContainer = document.getElementById('latest-container');
   latestContainer.className = latestContainer.className.replace( /(?:^|\s)invisible(?!\S)/g , ' animated fadeIn ' ); // make this section visible (invisible by default), with animated fade-in
-
-  displayLatestPlatform();
-  window.onhashchange = displayLatestPlatform;
 }
 
 /* eslint-disable no-unused-vars */

--- a/src/json/config.json
+++ b/src/json/config.json
@@ -15,6 +15,9 @@
       "binaryExtension": ".tar.gz",
       "installerExtension": "no-installer-available",
       "architecture": "64",
+      "installCommand": "tar -xf FILENAME",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "sha256sum FILENAME",
       "osDetectionString": "Linux Mint Debian Fedora FreeBSD Gentoo Haiku Kubuntu OpenBSD Red Hat RHEL SuSE Ubuntu Xubuntu hpwOS webOS Tizen"
     },
     {
@@ -24,6 +27,9 @@
       "binaryExtension": ".zip",
       "installerExtension": ".msi",
       "architecture": "64",
+      "installCommand": "unzip FILENAME",
+      "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
+      "checksumCommand": "certutil -hashfile FILENAME SHA256",
       "osDetectionString": "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP"
     },
     {
@@ -33,6 +39,9 @@
       "binaryExtension": ".tar.gz",
       "installerExtension": ".dmg",
       "architecture": "64",
+      "installCommand": "tar -xf FILENAME",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "shasum -a 256 FILENAME",
       "osDetectionString": "Mac OS X OSX macOS Macintosh"
     },
     {
@@ -42,6 +51,9 @@
       "binaryExtension": ".tar.gz",
       "installerExtension": "no-installer-available",
       "architecture": "64",
+      "installCommand": "tar -xf FILENAME",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "sha256sum FILENAME",
       "osDetectionString": "not-to-be-detected"
     },
     {
@@ -51,6 +63,9 @@
       "binaryExtension": ".tar.gz",
       "installerExtension": "no-installer-available",
       "architecture": "64",
+      "installCommand": "tar -xf FILENAME",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "sha256sum FILENAME",
       "osDetectionString": "not-to-be-detected"
     },
     {
@@ -60,6 +75,9 @@
       "binaryExtension": ".tar.gz",
       "installerExtension": "no-installer-available",
       "architecture": "64",
+      "installCommand": "tar -xf FILENAME",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "sha256sum FILENAME",
       "osDetectionString": "not-to-be-detected"
     },
     {
@@ -69,6 +87,9 @@
       "binaryExtension": ".tar.gz",
       "installerExtension": "no-installer-available",
       "architecture": "32",
+      "installCommand": "tar -xf FILENAME",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "sha256sum FILENAME",
       "osDetectionString": "not-to-be-detected"
     },
     {
@@ -78,6 +99,9 @@
       "binaryExtension": ".tar.gz",
       "installerExtension": "no-installer-available",
       "architecture": "64",
+      "installCommand": "gunzip -c FILENAME | tar xf -",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "shasum -a 256 FILENAME",
       "osDetectionString": "not-to-be-detected"
     }
   ]

--- a/src/scss/styles-1-large-main.scss
+++ b/src/scss/styles-1-large-main.scss
@@ -384,6 +384,7 @@ main {
 
 .info-page-container li {
   margin-top: 2rem;
+  line-height: 1.8rem;
 }
 
 pre {
@@ -409,6 +410,10 @@ code.hljs {
   background: inherit;
 }
 
+span.hljs-keyword, span.hljs-selector-tag, span.hljs-literal, span.hljs-doctag, span.hljs-title, span.hljs-section, span.hljs-type, span.hljs-name, span.hljs-strong {
+  font-weight: normal;
+}
+
 .callout {
   background-color: $translucent-blue;
   border-left: 0.5rem solid $mainblue;
@@ -416,9 +421,8 @@ code.hljs {
 }
 
 // SELECT ELEMENT - REMOVING DEFAULT STYLING
-select#variant-selector {
+select#variant-selector, select#platform-selector {
   // CHANGE FROM DISPLAY NONE TO DISPLAY BLOCK TO ACTIVATE VARIANT SELECTOR
-  display: none;
   margin: auto;
   margin-top: 2rem;
   -webkit-appearance: none;
@@ -432,21 +436,26 @@ select#variant-selector {
   cursor: pointer;
 }
 
-select#variant-selector:hover {
+select#variant-selector {
+  // CHANGE FROM DISPLAY NONE TO DISPLAY BLOCK TO ACTIVATE VARIANT SELECTOR
+  display: none;
+}
+
+select#variant-selector:hover, select#platform-selector:hover {
   background-color: #eaebec;
 }
 
-select#variant-selector:focus {
+select#variant-selector:focus, select#platform-selector:focus {
   outline:0;
 }
 
 
-select#variant-selector::-ms-expand {
+select#variant-selector::-ms-expand, select#platform-selector::-ms-expand {
     display: none;
 }
 
 @media screen and (min-width:0\0) {
-  select#variant-selector {
+  select#variant-selector, select#platform-selector {
     background:none\9;
     padding: 5px\9;
   }

--- a/src/scss/styles-1-large-main.scss
+++ b/src/scss/styles-1-large-main.scss
@@ -388,6 +388,8 @@ main {
 }
 
 pre {
+  display: flex;
+  justify-content: space-between;
   background-color: $mainblue;
   border-radius: 0.2rem;
   box-sizing: border-box;
@@ -395,12 +397,12 @@ pre {
   font-family: Consolas, monospace;
   overflow: auto;
   padding: 0.6rem;
-  padding-left: 1rem;
+  padding-left: 0;
   white-space: pre-wrap;
+  line-height: 1rem;
 }
 
 code {
-  box-sizing: border-box;
   overflow: auto;
   white-space: pre;
 }
@@ -408,6 +410,24 @@ code {
 code.hljs {
   padding: 0;
   background: inherit;
+  display: inline;
+}
+
+.copy-code-button, code.hljs {
+  padding: 0.2rem 1rem;
+}
+
+.copy-code-button {
+  display: inline-flex;
+  cursor: pointer;
+  background-color: rgba(255, 255, 255, 0.3);
+  font-size: 0.8rem;
+  border-radius: 0.2rem;
+  margin-left: 0.2rem;
+}
+
+.copy-code-button:hover {
+  background-color: rgba(255, 255, 255, 0.5);
 }
 
 span.hljs-keyword, span.hljs-selector-tag, span.hljs-literal, span.hljs-doctag, span.hljs-title, span.hljs-section, span.hljs-type, span.hljs-name, span.hljs-strong {

--- a/src/scss/styles-3-nightly.scss
+++ b/src/scss/styles-3-nightly.scss
@@ -105,7 +105,6 @@ table.ui-datepicker-calendar td {
   display: inline-block !important;
 }
 
-// HIDES THE WINDOWS COLUMN IN THE NIGHTLY TABLE
-#nightly-table tr td:nth-child(3), #nightly-table th:nth-child(3) {
-  /*display: none;*/
+#ui-datepicker-div {
+  display: none;
 }


### PR DESCRIPTION
[ON STAGING - Installation](https://staging.adoptopenjdk.net/installation.html)
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)

- The installation page is now dynamically populated, similar to the other main pages.
- The user has a drop-down list of platforms to choose from.
- If the user's OS is recognised and matches a supported platform, the relevant platform is selected and displayed on page load - UNLESS a platform has already been specified (via the URL, if for example you send someone a link to that specific platform installation instructions).
- The installation instructions now contain the EXACT commands that users will need to run, to install the latest binary for their selected platform (thanks for the suggestion @gdams)
- `config.js` contains the 'template' unzip, path, and checksum commands for each platform.