### PR TITLE
Add Installers to Home Page and Archive.

### DIFF
--- a/src/handlebars/archive.handlebars
+++ b/src/handlebars/archive.handlebars
@@ -23,11 +23,9 @@
 
     <div id="archive-list" class="hide">
       <select id="variant-selector"></select>
-
       <div id="pagination-container"></div>
       <table class='archive-container'>
         <tbody id='archive-table-body'>
-
           <!-- BEGIN HANDLEBARS LIVE-RENDERED TEMPLATE -->
           <script id="template" type="text/x-handlebars-template">
             \{{#each htmlTemplate}}
@@ -39,16 +37,46 @@
                   </div>
                 </td>
                 <td>
+
                   <table class='archive-platforms'>
+                    <tr class='column-names'>
+                      <td>
+                      </td>
+                      \{{#if installersExist}}
+                      <td>
+                        <span>Installer</span>
+                      </td>
+                      \{{/if}}
+                      \{{#if binariesExist}}
+                      <td>
+                        <span>Binary</span>
+                      </td>
+                      \{{/if}}
+                    </tr>
+
                     \{{#each thisPlatformAssets}}
                       <tr class='platform-row \{{thisPlatform}}'>
                         <td>\{{thisOfficialName}}</td>
+                        \{{#if ../installersExist}}
+                        <td class='download-td'>
+                          \{{#if thisInstallerExists}}
+                          <a class='blue-button no-underline' href='\{{thisInstallerLink}}'><var binary-info>\{{thisInstallerExtension}} (\{{thisInstallerSize}} MB)</var>
+                            {{> jck-tick }}
+                          </a>
+                          \{{else}}
+                          <div class='empty-download'>&nbsp;</div>
+                          \{{/if}}
+                        </td>
+                        \{{/if}}
+
+                        \{{#if thisBinaryExists}}
                         <td class='download-td'>
                           <a class='grey-button no-underline' href='\{{thisBinaryLink}}'><var binary-info>\{{thisBinaryExtension}} (\{{thisBinarySize}} MB)</var>
                             {{> jck-tick }}
                           </a>
                         </td>
                         <td><a href='\{{thisChecksumLink}}' class='dark-link'>Checksum</a></td>
+                        \{{/if}}
                       </tr>
                     \{{/each}}
                   </table>

--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -72,11 +72,24 @@ function buildArchiveHTML(releasesJson) {
       // firstly, check if the platform name is recognised...
       if(ASSETOBJECT.thisPlatform) {
 
+        // if the filename contains both the platform name and the matching INSTALLER extension, add the relevant info to the asset object
+        ASSETOBJECT.thisInstallerExtension = getInstallerExt(ASSETOBJECT.thisPlatform);
+        if(uppercaseFilename.indexOf(ASSETOBJECT.thisInstallerExtension.toUpperCase()) >= 0) {
+          ASSETOBJECT.thisPlatformExists = true;
+          ASSETOBJECT.thisInstallerExists = true;
+          RELEASEOBJECT.installersExist = true;
+          ASSETOBJECT.thisInstallerLink = (eachAsset.browser_download_url);
+          ASSETOBJECT.thisInstallerSize = Math.floor((eachAsset.size)/1024/1024);
+        }
+
         // secondly, check if the file has the expected file extension for that platform...
         // (this filters out all non-binary attachments, e.g. SHA checksums - these contain the platform name, but are not binaries)
         ASSETOBJECT.thisBinaryExtension = getBinaryExt(ASSETOBJECT.thisPlatform); // get the file extension associated with this platform
         if(uppercaseFilename.indexOf(ASSETOBJECT.thisBinaryExtension.toUpperCase()) >= 0) {
           // set values ready to be injected into the HTML
+          ASSETOBJECT.thisPlatformExists = true;
+          ASSETOBJECT.thisBinaryExists = true;
+          RELEASEOBJECT.binariesExist = true;
           ASSETOBJECT.thisOfficialName = getOfficialName(ASSETOBJECT.thisPlatform);
           ASSETOBJECT.thisBinaryLink = (eachAsset.browser_download_url);
           ASSETOBJECT.thisBinarySize = Math.floor((eachAsset.size)/1024/1024);
@@ -84,6 +97,9 @@ function buildArchiveHTML(releasesJson) {
           ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
           ASSETOBJECT.thisVerified = false;
 
+        }
+
+        if(ASSETOBJECT.thisPlatformExists === true){
           ASSETARRAY.push(ASSETOBJECT);
         }
       }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -60,7 +60,7 @@ function buildHomepageHTML(releasesJson) {
       var nameOfFile = eachAsset.name;
       var uppercaseFilename = nameOfFile.toUpperCase();
       var thisPlatform = getSearchableName(uppercaseFilename); // get the searchableName, e.g. X64_MAC or X64_LINUX.
-
+      var uppercaseOSname = null;
       // firstly, check if a valid searchableName has been returned (i.e. the platform is recognised)...
       if(thisPlatform) {
 
@@ -70,7 +70,7 @@ function buildHomepageHTML(releasesJson) {
         var thisInstallerExtension = getInstallerExt(thisPlatform); // get the installer extension associated with this platform
         if(matchingFile == null){
           if(uppercaseFilename.indexOf(thisInstallerExtension.toUpperCase()) >= 0) {
-            var uppercaseOSname = OS.searchableName.toUpperCase();
+            uppercaseOSname = OS.searchableName.toUpperCase();
 
             // thirdly, check if the user's OS searchableName string matches part of this binary's name (e.g. ...X64_LINUX...)
             if(uppercaseFilename.indexOf(uppercaseOSname) >= 0) {
@@ -78,7 +78,7 @@ function buildHomepageHTML(releasesJson) {
             }
           }
           else if(uppercaseFilename.indexOf(thisBinaryExtension.toUpperCase()) >= 0) {
-            var uppercaseOSname = OS.searchableName.toUpperCase();
+            uppercaseOSname = OS.searchableName.toUpperCase();
 
             // thirdly, check if the user's OS searchableName string matches part of this binary's name (e.g. ...X64_LINUX...)
             if(uppercaseFilename.indexOf(uppercaseOSname) >= 0) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -52,7 +52,7 @@ function buildHomepageHTML(releasesJson) {
   });
 
   var OS = detectOS(); // set a variable as an object containing all information about the user's OS (from the global.js 'platforms' array)
-  var matchingBinary = null;
+  var matchingFile = null;
 
   // if the OS has been detected...
   if(OS) {
@@ -66,13 +66,24 @@ function buildHomepageHTML(releasesJson) {
 
         // secondly, check if the file has the expected file extension for that platform...
         // (this filters out all non-binary attachments, e.g. SHA checksums - these contain the platform name, but are not binaries)
-        var thisBinaryExtension = getBinaryExt(thisPlatform); // get the file extension associated with this platform
-        if(uppercaseFilename.indexOf(thisBinaryExtension.toUpperCase()) >= 0) {
-          var uppercaseOSname = OS.searchableName.toUpperCase();
+        var thisBinaryExtension = getBinaryExt(thisPlatform); // get the binary extension associated with this platform
+        var thisInstallerExtension = getInstallerExt(thisPlatform); // get the installer extension associated with this platform
+        if(matchingFile == null){
+          if(uppercaseFilename.indexOf(thisInstallerExtension.toUpperCase()) >= 0) {
+            var uppercaseOSname = OS.searchableName.toUpperCase();
 
-          // thirdly, check if the user's OS searchableName string matches part of this binary's name (e.g. ...X64_LINUX...)
-          if(uppercaseFilename.indexOf(uppercaseOSname) >= 0) {
-            matchingBinary = eachAsset; // set the matchingBinary variable to the object containing this binary
+            // thirdly, check if the user's OS searchableName string matches part of this binary's name (e.g. ...X64_LINUX...)
+            if(uppercaseFilename.indexOf(uppercaseOSname) >= 0) {
+              matchingFile = eachAsset; // set the matchingFile variable to the object containing this binary
+            }
+          }
+          else if(uppercaseFilename.indexOf(thisBinaryExtension.toUpperCase()) >= 0) {
+            var uppercaseOSname = OS.searchableName.toUpperCase();
+
+            // thirdly, check if the user's OS searchableName string matches part of this binary's name (e.g. ...X64_LINUX...)
+            if(uppercaseFilename.indexOf(uppercaseOSname) >= 0) {
+              matchingFile = eachAsset; // set the matchingFile variable to the object containing this binary
+            }
           }
         }
       }
@@ -80,27 +91,27 @@ function buildHomepageHTML(releasesJson) {
   }
 
   // if there IS a matching binary for the user's OS...
-  if(matchingBinary) {
-    dlLatest.href = matchingBinary.browser_download_url; // set the main download button's link to be the binary's download url
+  if(matchingFile) {
+    dlLatest.href = matchingFile.browser_download_url; // set the main download button's link to be the binary's download url
     dlText.innerHTML = ('Download for <var platform-name>' + OS.officialName + '</var>'); // set the text to be OS-specific, using the full OS name.
-    var thisBinarySize = Math.floor((matchingBinary.size)/1024/1024);
+    var thisBinarySize = Math.floor((matchingFile.size)/1024/1024);
     dlVersionText.innerHTML += (' - ' + thisBinarySize + ' MB');
-    if(matchingBinary.jck === true) {
+    if(matchingFile.jck === true) {
       document.getElementById('jck-approved-tick').classList.remove('hide');
       setTickLink();
     }
   }
   // if there is NOT a matching binary for the user's OS...
   else {
-    dlOther.className += ' hide'; // hide the 'Other platforms' button
-    dlIcon.className += ' hide'; // hide the download icon on the main button, to make it look less like you're going to get a download immediately
-    dlIcon2.className = dlIcon2.className.replace( /(?:^|\s)hide(?!\S)/g , '' ); // un-hide an arrow-right icon to show instead
+    dlOther.classList.add('hide'); // hide the 'Other platforms' button
+    dlIcon.classList.add('hide'); // hide the download icon on the main button, to make it look less like you're going to get a download immediately
+    dlIcon2.classList.remove('hide'); // un-hide an arrow-right icon to show instead
     dlText.innerHTML = ('Downloads'); // change the text to be generic: 'Downloads'.
     dlLatest.href = './releases.html'; // set the main download button's link to the latest builds page for all platforms.
   }
 
   // remove the loading dots, and make all buttons visible, with animated fade-in
-  loading.innerHTML = '';
+  loading.classList.add('hide');
   dlLatest.className = dlLatest.className.replace( /(?:^|\s)invisible(?!\S)/g , ' animated ' );
   dlOther.className = dlOther.className.replace( /(?:^|\s)invisible(?!\S)/g , ' animated ' );
   dlArchive.className = dlArchive.className.replace( /(?:^|\s)invisible(?!\S)/g , ' animated ' );

--- a/src/scss/styles-1-large-main.scss
+++ b/src/scss/styles-1-large-main.scss
@@ -371,6 +371,17 @@ main {
   text-decoration: none;
 }
 
+.empty-download{
+  border-radius: 0.2rem;
+  font-size: inherit;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  background-color: rgba(61, 112, 178, 0.18);
+  padding: 0 1.5rem;
+  line-height: 2rem;
+  display: inline-block;
+}
 #search-error {
   text-align: center;
   margin-top: 2rem;

--- a/src/scss/styles-11-archive.scss
+++ b/src/scss/styles-11-archive.scss
@@ -26,11 +26,13 @@ $tableblue-even: #1F2F4E;
   font-size: 0.8rem;
 }
 
-.archive-container .grey-button {
-  font-size: inherit;
-  width: 100%;
-  box-sizing: border-box;
-  margin: 0;
+.archive-container {
+  .grey-button, .blue-button  {
+    font-size: inherit;
+    width: 100%;
+    box-sizing: border-box;
+    margin: 0;
+  }
 }
 
 .archive-container .download-td {
@@ -56,4 +58,10 @@ $tableblue-even: #1F2F4E;
   img {
     height: 1.2rem;
   }
+}
+
+.column-names span{
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  display: inline-block;
 }


### PR DESCRIPTION
Fixes #170 
[ON STAGING](https://staging.adoptopenjdk.net) 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)

Added capability for installers to be displayed on the Archive page and set capability and preference for installer on the main home page button. 