### PR TITLE
Point to the right github page for tests.

### DIFF
--- a/src/handlebars/getinvolved.handlebars
+++ b/src/handlebars/getinvolved.handlebars
@@ -62,8 +62,8 @@
         <li><a href="https://github.com/AdoptOpenJDK/openjdk-build" target="_blank">openjdk-build</a> -
             <a href="https://github.com/AdoptOpenJDK/openjdk-build/wiki" target="_blank">(wiki)</a>
             - Build scripts and other infrastructure to create binaries</li>
-        <li><a href="https://github.com/AdoptOpenJDK/openjdk-test" target="_blank">openjdk-test</a> -
-            <a href="https://github.com/AdoptOpenJDK/openjdk-test/wiki" target="_blank">(wiki)</a>
+        <li><a href="https://github.com/AdoptOpenJDK/openjdk-tests" target="_blank">openjdk-tests</a> -
+            <a href="https://github.com/AdoptOpenJDK/openjdk-tests/wiki" target="_blank">(wiki)</a>
             - Test scripts and other infrastructure to test binaries</li>
         <li><a href="https://github.com/AdoptOpenJDK/openjdk-website" target="_blank">openjdk-website</a> -
             <a href="https://github.com/AdoptOpenJDK/openjdk-website/wiki" target="_blank">(wiki)</a>


### PR DESCRIPTION
Fix minor typo in the getinvolved page.

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)