### PR TITLE
Add docker link to the front of the adoptopenjdk website

### DIFF
--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -5,7 +5,8 @@
   <p class="intro">
     Java™ is the world's leading programming language and platform. The code for Java is <a href="http://openjdk.java.net/legal/gplv2+ce.html" target="_blank">open source</a> and available at
     <a href="http://openjdk.java.net" target="_blank">OpenJDK</a>™. AdoptOpenJDK provides prebuilt OpenJDK binaries
-    from a fully open source set of <a href="https://github.com/AdoptOpenJDK/openjdk-build" target="_blank">build scripts</a> and infrastructure.
+    from a fully open source set of <a href="https://github.com/AdoptOpenJDK/openjdk-build" target="_blank">build scripts</a> and infrastructure.<br/>
+    Looking for docker images? Pull them from <a href="https://hub.docker.com/u/adoptopenjdk">our repository on dockerhub</a>
   </p>
 
   <div class="dl-container">


### PR DESCRIPTION
It's not obvious from our main web site that we provide docker images - this PR adds a link to the front page and makes it clear which repository on dockerhub is the one maintained by the adoptopenjdk project. Hopefully this isn't too controversial ;-)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
