### PR TITLE
Add link to the meetings diary

### DIFF
--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -62,6 +62,8 @@
       <a href="./about.html"><h3 class="inline-block zero-margin">About</h3></a>
       <span> | </span>
       <a target="_blank" href="http://api.adoptopenjdk.net"><h3 class="inline-block zero-margin">API</h3></a>
+      <span> | </span>
+      <a target="_blank" href="https://calendar.adoptopenjdk.net"><h3 class="inline-block zero-margin">Meeting diary</h3></a>
     </div>
   </div>
 


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-website/issues/207 - open to alternative suggestions as to where to locate this on the page but here's my "starter for 10"