### PR TITLE
add dynamic JCK status

### DIFF
--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -25,7 +25,7 @@
       </div>
       <div class="dl-description">
         <var id="dl-version-text" class="small-dl-text" release-version></var>
-        <span id="jck-approved-tick" class='tick hide' data-tooltip="This build is JCK compliant."><img src='./dist/assets/tick.png' alt="This build is JCK compliant."></span>
+        <span id="jck-approved-tick" class='tick hide' data-tooltip="This build is JCK certified."><img src='./dist/assets/tick.png' alt="This build is JCK certified."></span>
       </div>
     </a>
 

--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -25,7 +25,7 @@
       </div>
       <div class="dl-description">
         <var id="dl-version-text" class="small-dl-text" release-version></var>
-        <span id="jck-approved-tick" class='tick hide' data-tooltip="This build is JCK approved."><img src='./dist/assets/tick.png' alt="This build is JCK approved."></span>
+        <span id="jck-approved-tick" class='tick hide' data-tooltip="This build is JCK compliant."><img src='./dist/assets/tick.png' alt="This build is JCK compliant."></span>
       </div>
     </a>
 

--- a/src/handlebars/partials/jck-tick.handlebars
+++ b/src/handlebars/partials/jck-tick.handlebars
@@ -1,3 +1,3 @@
 \{{#if thisVerified}}
-  <span class='tick' data-tooltip="This build is JCK compliant."><img src='./dist/assets/tick.png' alt="This build is JCK compliant."></span>
+  <span class='tick' data-tooltip="This build is JCK certified."><img src='./dist/assets/tick.png' alt="This build is JCK certified."></span>
 \{{/if}}

--- a/src/handlebars/partials/jck-tick.handlebars
+++ b/src/handlebars/partials/jck-tick.handlebars
@@ -1,3 +1,3 @@
 \{{#if thisVerified}}
-  <span class='tick' data-tooltip="This build is JCK approved."><img src='./dist/assets/tick.png' alt="This build is JCK approved."></span>
+  <span class='tick' data-tooltip="This build is JCK compliant."><img src='./dist/assets/tick.png' alt="This build is JCK compliant."></span>
 \{{/if}}

--- a/src/js/0-global.js
+++ b/src/js/0-global.js
@@ -141,21 +141,24 @@ function detectOS() {
 // when using this function, pass in the name of the repo (options: releases, nightly)
 function loadJSON(repo, filename, callback) {
   var url = ('https://raw.githubusercontent.com/AdoptOpenJDK/' + repo + '/master/' + filename + '.json'); // the URL of the JSON built in the website back-end
-
   if(repo === 'adoptopenjdk.net') {
     url = (filename);
   }
-
   var xobj = new XMLHttpRequest();
-  xobj.open('GET', url, true);
+  xobj.open('GET', url, true)
   xobj.onreadystatechange = function () {
     if (xobj.readyState == 4 && xobj.status == '200') { // if the status is 'ok', run the callback function that has been passed in.
       callback(xobj.responseText);
     } else if (
       xobj.status != '200' && // if the status is NOT 'ok', remove the loading dots, and display an error:
       xobj.status != '0') { // for IE a cross domain request has status 0, we're going to execute this block fist, than the above as well.
-      loading.innerHTML = '';
-      document.getElementById('error-container').innerHTML = '<p>Error... there\'s a problem fetching the releases. Please see the <a href=\'https://github.com/AdoptOpenJDK/openjdk-releases/releases\' target=\'blank\'>releases list on GitHub</a>.</p>';
+        if (filename !== 'jck') {
+          document.getElementById('error-container').innerHTML = '<p>Error... there\'s a problem fetching the releases. Please see the <a href=\'https://github.com/AdoptOpenJDK/openjdk-releases/releases\' target=\'blank\'>releases list on GitHub</a>.</p>';
+          loading.innerHTML = '';
+        } else {
+          loading.innerHTML = '';
+          callback(null)
+        }
     }
   };
   xobj.send(null);
@@ -260,9 +263,9 @@ function setVariantSelector() {
     if(!variant) {
       variant = variants[0].searchableName;
     }
-    
+
     variantSelector.value = variant;
-    
+
     if(variantSelector.value === '') {
       var op = new Option();
       op.value = 'unknown';

--- a/src/js/0-global.js
+++ b/src/js/0-global.js
@@ -145,7 +145,7 @@ function loadJSON(repo, filename, callback) {
     url = (filename);
   }
   var xobj = new XMLHttpRequest();
-  xobj.open('GET', url, true)
+  xobj.open('GET', url, true);
   xobj.onreadystatechange = function () {
     if (xobj.readyState == 4 && xobj.status == '200') { // if the status is 'ok', run the callback function that has been passed in.
       callback(xobj.responseText);

--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -107,7 +107,7 @@ function buildArchiveHTML(releasesJson, jckJSON) {
           if (Object.keys(jckJSON).length == 0) {
             ASSETOBJECT.thisVerified = false;
           } else {
-            if (jckJSON[eachRelease.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
+            if (jckJSON[eachRelease.name] && jckJSON[eachRelease.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
               ASSETOBJECT.thisVerified = true;
             } else {
               ASSETOBJECT.thisVerified = false;
@@ -140,7 +140,7 @@ function buildArchiveHTML(releasesJson, jckJSON) {
             if (Object.keys(jckJSON).length == 0) {
               ASSETOBJECT.thisVerified = false;
             } else {
-              if (jckJSON[eachRelease.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
+              if (jckJSON[eachRelease.name] && jckJSON[eachRelease.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
                 ASSETOBJECT.thisVerified = true;
               } else {
                 ASSETOBJECT.thisVerified = false;

--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -29,7 +29,13 @@ function populateArchive() {
 
       // if there are releases prior to the 'latest' one (i.e. archived releases)...
       if (typeof releasesJson[0] !== 'undefined') {
-        buildArchiveHTML(releasesJson);
+        loadJSON(repoName, 'jck', function(response_jck) {
+          var jckJSON = {}
+          if (response_jck !== null){
+            jckJSON = JSON.parse(response_jck)
+          }
+          buildArchiveHTML(releasesJson, jckJSON);
+        });
       } else { // if there are no releases (beyond the latest one)...
         // report an error, remove the loading dots
         loading.innerHTML = '';
@@ -40,7 +46,7 @@ function populateArchive() {
 
 }
 
-function buildArchiveHTML(releasesJson) {
+function buildArchiveHTML(releasesJson, jckJSON) {
   var RELEASEARRAY = [];
 
   // for each release...
@@ -98,7 +104,15 @@ function buildArchiveHTML(releasesJson) {
           ASSETOBJECT.thisBinarySize = Math.floor((eachAsset.size)/1024/1024);
           ASSETOBJECT.thisChecksumLink = (eachAsset.browser_download_url).replace(ASSETOBJECT.thisInstallerExtension, '.sha256.txt');
           ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
-          ASSETOBJECT.thisVerified = false;
+          if (Object.keys(jckJSON).length == 0) {
+            ASSETOBJECT.thisVerified = false;
+          } else {
+            if (jckJSON[eachRelease.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
+              ASSETOBJECT.thisVerified = true;
+            } else {
+              ASSETOBJECT.thisVerified = false;
+            }
+          }
         }
 
         // secondly, check if the file has the expected file extension for that platform...
@@ -123,7 +137,15 @@ function buildArchiveHTML(releasesJson) {
             ASSETOBJECT.thisBinarySize = Math.floor((eachAsset.size)/1024/1024);
             ASSETOBJECT.thisChecksumLink = (eachAsset.browser_download_url).replace(ASSETOBJECT.thisBinaryExtension, '.sha256.txt');
             ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
-            ASSETOBJECT.thisVerified = false;
+            if (Object.keys(jckJSON).length == 0) {
+              ASSETOBJECT.thisVerified = false;
+            } else {
+              if (jckJSON[eachRelease.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
+                ASSETOBJECT.thisVerified = true;
+              } else {
+                ASSETOBJECT.thisVerified = false;
+              }
+            }
           }
         }
 

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -75,7 +75,7 @@ function buildLatestHTML(releasesJson, jckJSON) {
       if (Object.keys(jckJSON).length == 0) {
         ASSETOBJECT.thisVerified = false;
       } else {
-        if (jckJSON[releasesJson.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
+        if (jckJSON[releasesJson.name] && jckJSON[releasesJson.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
           ASSETOBJECT.thisVerified = true;
         } else {
           ASSETOBJECT.thisVerified = false;

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -19,7 +19,13 @@ function populateLatest() {
     loadJSON(repoName, 'latest_release', function(response) {
       var releasesJson = JSON.parse(response);
       if (typeof releasesJson !== 'undefined') { // if there are releases...
-        buildLatestHTML(releasesJson);
+        loadJSON(repoName, 'jck', function(response_jck) {
+          var jckJSON = {}
+          if (response_jck !== null){
+            jckJSON = JSON.parse(response_jck)
+          }
+          buildLatestHTML(releasesJson, jckJSON);
+        });
       }
       else {
         // report an error
@@ -30,7 +36,7 @@ function populateLatest() {
   });
 }
 
-function buildLatestHTML(releasesJson) {
+function buildLatestHTML(releasesJson, jckJSON) {
 
   // populate with description
   var variantObject = getVariantObject(variant);
@@ -66,7 +72,15 @@ function buildLatestHTML(releasesJson) {
       ASSETOBJECT.thisLogo = getLogo(ASSETOBJECT.thisPlatform);
       ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
       ASSETOBJECT.thisOfficialName = getOfficialName(ASSETOBJECT.thisPlatform);
-      ASSETOBJECT.thisVerified = false;
+      if (Object.keys(jckJSON).length == 0) {
+        ASSETOBJECT.thisVerified = false;
+      } else {
+        if (jckJSON[releasesJson.name].hasOwnProperty(ASSETOBJECT.thisPlatform) ) {
+          ASSETOBJECT.thisVerified = true;
+        } else {
+          ASSETOBJECT.thisVerified = false;
+        }
+      }
 
       // if the filename contains both the platform name and the matching INSTALLER extension, add the relevant info to the asset object
       ASSETOBJECT.thisInstallerExtension = getInstallerExt(ASSETOBJECT.thisPlatform);

--- a/src/scss/styles-4-releases.scss
+++ b/src/scss/styles-4-releases.scss
@@ -142,6 +142,11 @@ $tableblue-even: #1F2F4E;
   color: rgba(255, 255, 255, .7);
 }
 
+.tick img {
+    height: 2.0rem !important;
+    padding-top: 10px;
+}
+
 .latest-block a.a-button {
   min-width: 12rem;
   box-sizing: border-box;


### PR DESCRIPTION
This PR allows us to dynamically set which platforms are JCK approved for a specific platform release.

## How will we mark binaries as JCK compliant?

We will have a jck.json file in a release repo. It will look something like this:
```JSON
{
  "jdk8u152-b16": {
    "PPC64LE_LINUX": "true"
  }
}
```

I have added a file here for testing: https://github.com/AdoptOpenJDK/openjdk8-openj9-releases/blob/master/jck.json.

NOTE that the CSS doesn't look fantastic on this. Perhaps @EnriqueL8 could take a look and pick this up later on but for now this is the important work.

## Staging
https://staging.adoptopenjdk.net/releases.html?variant=openjdk8-openj9#ppc64le_linux