### PR TITLE
Update support page quality statements around JCK testing

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -10,15 +10,26 @@
       <h2 class="bold">Quality</h2>
       <p>
         The binaries that AdoptOpenJDK produces have passed the full OpenJDK test suite and other tests (donated by the community)
-        ensuring a good quality binary. However, they are <strong>not</strong> JCK/TCK compliant. If you want a formally (JCK/TCK)
-        tested and verified Java binary then you can get one from a commercial vendor.
+        ensuring a good quality binary. But not all binaries have passed the full JCK/TCK compliance testing. Binaries that have
+        passed full JCK testing can be identified by the blue shield containing a check mark in their download button (example
+        below).
       </p>
+        <div class="inline-block">
+          <div class='latest-block'>
+            <span>Installer</span>
+            {{> jck-tick }}
+            <div class='large-dl-text'>Download
+              <div class='small-dl-text'><var installer-info>.tar.gz - 79 MB</var></div>
+            </div>
+          </div>
+        </div>
     </div>
 
     <div class="margin-bottom">
       <h2 class="bold">Community Support</h2>
       <p>
-        The OpenJDK community does not offer any commercial support for the binaries produced.  If you do have questions, comments, want to report a bug or
+        The OpenJDK community does not offer any commercial support for the binaries produced here, but some vendors may offer
+        commercial support for (some of) the binaries produced here. If you do have questions, comments, want to report a bug or
         wish to contribute then choose from one of the options below (please post on the mailing list to get access to Slack):
       </p>
     </div>


### PR DESCRIPTION
Since we're now performing JCK testing and have proven and marked
some builds as JCK compliant, update the language on the support
page to reflect that.

Note this change includes a probably incomplete update to include a
"sample" of the download box that has the jck tick mark, so
that will probably need to be fixed before actually merging.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
