### PR TITLE
Fixed css for div.dl-description (#227)

### DIFF
--- a/src/scss/styles-2-index.scss
+++ b/src/scss/styles-2-index.scss
@@ -66,6 +66,7 @@ a.dl-button .dl-description {
   left: 50%;
   white-space: nowrap;
   transform: translate(-50%,-3.8rem);
+  height: 50%; /* div take 100% of a tag height and goes out of bound */
 }
 
 a.dl-button:hover {


### PR DESCRIPTION
Div by default take 100% of height of parent element
due to transformation it was going out of bounds, and link were overflowing

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
