### PR TITLE
Update the default selected build to be OpenJDK10

### DIFF
--- a/src/json/config.json
+++ b/src/json/config.json
@@ -11,7 +11,7 @@
       "descriptionLink" : "http://www.eclipse.org/openj9"
     },{
       "searchableName": "openjdk9",
-      "officialName": "OpenJDK 9 with Hotspot",
+      "officialName": "OpenJDK 9 with Hotspot"
     },{
       "searchableName": "openjdk9-openj9",
       "officialName": "OpenJDK 9 with Eclipse OpenJ9",
@@ -19,7 +19,7 @@
       "descriptionLink" : "http://www.eclipse.org/openj9"
     },{
       "searchableName": "openjdk10",
-      "officialName": "OpenJDK 10 with Hotspot"
+      "officialName": "OpenJDK 10 with Hotspot",
       "default": true
     },{
       "searchableName": "openjdk10-openj9",

--- a/src/json/config.json
+++ b/src/json/config.json
@@ -12,7 +12,6 @@
     },{
       "searchableName": "openjdk9",
       "officialName": "OpenJDK 9 with Hotspot",
-      "default": true
     },{
       "searchableName": "openjdk9-openj9",
       "officialName": "OpenJDK 9 with Eclipse OpenJ9",
@@ -21,6 +20,7 @@
     },{
       "searchableName": "openjdk10",
       "officialName": "OpenJDK 10 with Hotspot"
+      "default": true
     },{
       "searchableName": "openjdk10-openj9",
       "officialName": "OpenJDK 10 with Eclipse OpenJ9",


### PR DESCRIPTION
Keep pace with the 6 month release cadence by updating the default selected build to be OpenJDK 10 with Hotspot

- [X] `npm test` passes
- [X] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
