### PR TITLE
Links to projects used for AdoptOpenJDK builds

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -40,7 +40,7 @@
     </div>
     <div class="margin-bottom">
       <p>
-        The frequency of AdoptOpenJDK releases is guided by the schedule of our dependencies. We produce builds based upon source code at OpenJDK, Eclipse OpenJ9, and SAP Machine.
+        The frequency of AdoptOpenJDK releases is guided by the schedule of our dependencies. We produce builds based upon source code at <a href="http://openjdk.java.net" target="_blank">OpenJDK</a>, <a href="https://www.eclipse.org/openj9/" target="_blank">Eclipse OpenJ9</a>, and <a href="https://sap.github.io/SapMachine/" target="_blank">SAP Machine</a>.
         </br>
         </br>OpenJDK provides a new feature release every six months, and a maintenance/security update based upon each active release every three months. We will follow this schedule for publishing binary releases from AdoptOpenJDK to ensure you get the latest,
         most secure builds.


### PR DESCRIPTION
Added links to the web page of the three projects from which AdoptOpenJDK produces builds.  This makes those projects easier to find for those new to the fact that there are three options when choosing an OpenJDK build.

http://openjdk.java.net
https://www.eclipse.org/openj9/
https://sap.github.io/SapMachine/

Each link uses the _blank target as used by the links on the main page of AdoptOpenJDK page.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
