### PR TITLE
Remove link to defunct Slack archive

### DIFF
--- a/src/handlebars/slack.handlebars
+++ b/src/handlebars/slack.handlebars
@@ -4,10 +4,6 @@
 
   <h1 class="margin-bottom large-title">Slack Signup</h1>
 
-  <h3 class="intro">
-    Public Slack Archive available <a href="https://adoptopenjdk.slackarchive.io/" target="_blank">here</a>.
-  </h3>
-
   <iframe src="https://slackin-jmnmplfpdu.now.sh/" height="500" width="310"
         frameborder="0" scrolling="no" id="iframe"> ...
 </iframe>


### PR DESCRIPTION
Remove link to defunct Slack archive from Slack invitation page (https://adoptopenjdk.net/slack.html).

##### Checklist

- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
