### PR TITLE
Updating the AdoptOpenJDK website to include the jvm variant.

### DIFF
--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -29,7 +29,7 @@ function populateArchive() {
       // if there are no releases (beyond the latest one)...
       // report an error, remove the loading dots
       loading.innerHTML = '';
-      errorContainer.innerHTML = '<p>There are no archived releases yet! See the <a href=\'./releases.html?variant=' + variant + '\'>Latest release</a> page.</p>';
+      errorContainer.innerHTML = '<p>There are no archived releases yet for ' + variant + ' on the ' + jvmVariant + ' jvm. See the <a href=\'./releases.html?variant=' + variant + '&jvmVariant=' + jvmVariant + '\'>Latest release</a> page.</p>';
     });
   });
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -41,7 +41,7 @@ function setDownloadSection() {
 
     /* eslint-disable no-undef */
     loadAssetInfo(variant, jvmVariant, 'releases', 'latest', handleResponse, function () {
-      errorContainer.innerHTML = '<p>There are no releases available for ' + variant + '. Please check our <a href=nightly.html?variant=' + variant + ' target=\'blank\'>Nightly Builds</a>.</p>';
+      errorContainer.innerHTML = '<p>There are no releases available for ' + variant + ' on the ' + jvmVariant + ' jvm. Please check our <a href=nightly.html?variant=' + variant + '&jvmVariant=' + jvmVariant + ' target=\'blank\'>Nightly Builds</a>.</p>';
       loading.innerHTML = ''; // remove the loading dots
     });
   });

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -39,7 +39,7 @@ function populateLatest() {
     };
 
     loadAssetInfo(variant, jvmVariant, 'releases', 'latest', handleResponse, function () {
-      errorContainer.innerHTML = '<p>There are no releases available for ' + variant + '. Please check our <a href=nightly.html?variant=' + variant + ' target=\'blank\'>Nightly Builds</a>.</p>';
+      errorContainer.innerHTML = '<p>There are no releases available for ' + variant + ' on the ' + jvmVariant + ' jvm. Please check our <a href=nightly.html?variant=' + variant + '&jvmVariant=' + jvmVariant + ' target=\'blank\'>Nightly Builds</a>.</p>';
       loading.innerHTML = ''; // remove the loading dots
     });
   });


### PR DESCRIPTION
This makes the links consistent and improves the accuracy of error
messages.

See issue https://github.com/AdoptOpenJDK/openjdk-website/issues/276

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->