### PR TITLE
change java 11 banner to use proper banner

### DIFF
--- a/src/handlebars/banner.handlebars
+++ b/src/handlebars/banner.handlebars
@@ -1,1 +1,5 @@
-<!-- Leave this file empty. It is populated when the jenkins build runs. -->
+<!-- This is where you can add banners to the website -->
+  <div class="alert align-center">
+   <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
+   <strong>27th Sept 2018:</strong> We're actively working on our <strong>Java 11</strong> and <strong>Java 1.8.0_181</strong> releases, stay tuned!
+  </div>

--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -84,5 +84,3 @@
   <script>
       w3IncludeHTML();
   </script>
-
-  <div style="text-align: center; font-size: 2.0em; padding: 1.0em; line-height: 1.5em;"><span style="font-weight: bold;">27th Sept 2018:</span> We're actively working on our <br/> <span style="font-weight: bold;">Java 11</span> and <span style="font-weight: bold;">Java 1.8.0_181</span> releases, stay tuned!</div>


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)

This might not render well on staging as it already uses a different banner but this will work in production.