### PR TITLE
Include the '-jre' directory suffix for JRE PATH setup.

### DIFF
--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -56,7 +56,9 @@ function buildInstallationHTML(releasesJson) {
         ASSETOBJECT.thisChecksumFilename = eachAsset.binary_name.replace(ASSETOBJECT.thisBinaryExtension, '.sha256.txt');
         ASSETOBJECT.thisUnzipCommand = getInstallCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
         ASSETOBJECT.thisChecksumCommand = getChecksumCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
-        ASSETOBJECT.thisPathCommand = getPathCommand(ASSETOBJECT.thisPlatform).replace('DIRNAME', releasesJson.release_name);
+
+        var dirName = releasesJson.release_name + (eachAsset.binary_type === 'jre' ? '-jre' : '');
+        ASSETOBJECT.thisPathCommand = getPathCommand(ASSETOBJECT.thisPlatform).replace('DIRNAME', dirName);
       }
 
       if (ASSETOBJECT.thisPlatformExists === true) {


### PR DESCRIPTION
JRE archives contain a directory with `-jre` appended to the release name.  This PR ensures the installation page's PATH setup command includes the correct directory.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
