### PR TITLE
Sort archive releases by timestamp in descending order.  Addresses #342

### DIFF
--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -150,7 +150,7 @@ function buildArchiveHTML(releases, jckJSON) {
     RELEASEARRAY.push(RELEASEOBJECT);
   }
 
-  // Sort releases by in descending order
+  // Sort releases by date/timestamp in descending order
   RELEASEARRAY.sort(function (a, b) {
     return b.thisReleaseDate - a.thisReleaseDate;
   });

--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -1,6 +1,6 @@
 var ARCHIVEDATA;
 
-// When releases page loads, run:
+// When archive page loads, run:
 /* eslint-disable no-unused-vars */
 function onArchiveLoad() {
   /* eslint-enable no-unused-vars */
@@ -44,11 +44,12 @@ function buildArchiveHTML(releases, jckJSON) {
     var eachRelease = releases[i];
 
     // set values for this release, ready to inject into HTML
-    var publishedAt = eachRelease.timestamp;
+    var publishedAt = moment(eachRelease.timestamp);
     RELEASEOBJECT.thisReleaseName = eachRelease.release_name;
-    RELEASEOBJECT.thisReleaseDay = moment(publishedAt).format('D');
-    RELEASEOBJECT.thisReleaseMonth = moment(publishedAt).format('MMMM');
-    RELEASEOBJECT.thisReleaseYear = moment(publishedAt).format('YYYY');
+    RELEASEOBJECT.thisReleaseDate = publishedAt.toDate();
+    RELEASEOBJECT.thisReleaseDay = publishedAt.format('D');
+    RELEASEOBJECT.thisReleaseMonth = publishedAt.format('MMMM');
+    RELEASEOBJECT.thisReleaseYear = publishedAt.format('YYYY');
     RELEASEOBJECT.thisGitLink = ('https://github.com/AdoptOpenJDK/' + getRepoName(true, 'releases') + '/releases/tag/' + RELEASEOBJECT.thisReleaseName);
 
     // create an array of the details for each asset that is attached to this release
@@ -148,6 +149,11 @@ function buildArchiveHTML(releases, jckJSON) {
     RELEASEOBJECT.thisPlatformAssets = ASSETARRAY;
     RELEASEARRAY.push(RELEASEOBJECT);
   }
+
+  // Sort releases by in descending order
+  RELEASEARRAY.sort(function (a, b) {
+    return b.thisReleaseDate - a.thisReleaseDate;
+  });
 
   ARCHIVEDATA.htmlTemplate = RELEASEARRAY;
   var template = Handlebars.compile(document.getElementById('template').innerHTML);


### PR DESCRIPTION
This PR (related to #342) sorts archive releases by timestamp in descending order, which is consistent with GitHub releases, Oracle's archive page, etc.

There's also a minor tweak to reduce the number of `moment`s created.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
