### PR TITLE
Add a warning to the Archive page regarding use of old releases

### DIFF
--- a/src/handlebars/archive.handlebars
+++ b/src/handlebars/archive.handlebars
@@ -4,6 +4,11 @@
 
   <div id="archives-page">
     <h1 class="large-title">Archive</h1>
+
+    <div class="callout">
+      <p>Please be aware that using old, superseded, or otherwise unsupported releases is not recommended.</p>
+    </div>
+
     <a href="./releases.html" id="latest-button" class="blue-button a-button">
       <div>
         <span>Latest release</span>

--- a/src/scss/styles-11-archive.scss
+++ b/src/scss/styles-11-archive.scss
@@ -10,7 +10,7 @@ $tableblue-even: #1F2F4E;
 
 #archives-page .callout {
   max-width: 50rem;
-  margin: auto auto 2em;
+  margin: auto auto 2rem;
   text-align: left;
 }
 

--- a/src/scss/styles-11-archive.scss
+++ b/src/scss/styles-11-archive.scss
@@ -8,6 +8,12 @@ $tableblue-even: #1F2F4E;
 
 // ARCHIVE CSS
 
+#archives-page .callout {
+  max-width: 50rem;
+  margin: auto auto 2em;
+  text-align: left;
+}
+
 #archive-list {
   overflow: auto;
 }


### PR DESCRIPTION
This PR adds a warning to the Archive page regarding use of old releases.

##### Checklist
- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)