### PR TITLE
Use the provided release URL

### DIFF
--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -50,7 +50,7 @@ function buildArchiveHTML(releases, jckJSON) {
     RELEASEOBJECT.thisReleaseDay = publishedAt.format('D');
     RELEASEOBJECT.thisReleaseMonth = publishedAt.format('MMMM');
     RELEASEOBJECT.thisReleaseYear = publishedAt.format('YYYY');
-    RELEASEOBJECT.thisGitLink = ('https://github.com/AdoptOpenJDK/' + getRepoName(true, 'releases') + '/releases/tag/' + RELEASEOBJECT.thisReleaseName);
+    RELEASEOBJECT.thisGitLink = eachRelease.release_link;
 
     // create an array of the details for each asset that is attached to this release
     var assetArray = eachRelease.binaries;

--- a/src/js/nightly.js
+++ b/src/js/nightly.js
@@ -122,7 +122,7 @@ function buildNightlyHTML(files) {
       NIGHTLYOBJECT.thisReleaseDay = moment(publishedAt).format('D');
       NIGHTLYOBJECT.thisReleaseMonth = moment(publishedAt).format('MMMM');
       NIGHTLYOBJECT.thisReleaseYear = moment(publishedAt).format('YYYY');
-      NIGHTLYOBJECT.thisGitLink = ('https://github.com/AdoptOpenJDK/' + getRepoName(true, 'nightly') + '/releases/tag/' + eachRelease.release_name);
+      NIGHTLYOBJECT.thisGitLink = eachRelease.release_link;
       NIGHTLYOBJECT.thisOfficialName = getOfficialName(NIGHTLYOBJECT.thisPlatform);
       NIGHTLYOBJECT.thisBinaryLink = eachAsset.binary_link;
       NIGHTLYOBJECT.thisBinarySize = Math.floor(eachAsset.binary_size / 1024 / 1024);

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -57,7 +57,7 @@ function buildLatestHTML(releasesJson, jckJSON, assetArray) {
   // populate the page with the release's information
   var publishedAt = (releasesJson.timestamp);
   document.getElementById('latest-build-name').innerHTML = '<var release-name>' + releasesJson.release_name + '</var>';
-  document.getElementById('latest-build-name').href = ('https://github.com/AdoptOpenJDK/' + getRepoName(true, 'releases') + '/releases/tag/' + releasesJson.release_name);
+  document.getElementById('latest-build-name').href = releasesJson.release_link;
   document.getElementById('latest-date').innerHTML = ('<var>' + moment(publishedAt).format('D') + '</var> ' + moment(publishedAt).format('MMMM') + ' <var>' + moment(publishedAt).format('YYYY') + '</var>');
   document.getElementById('latest-timestamp').innerHTML = publishedAt;
 


### PR DESCRIPTION
This is to address AdoptOpenJDK/openjdk-website#286, and uses the new property introduced by AdoptOpenJDK/openjdk-api#102.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
