### PR TITLE
add link to download stats

### DIFF
--- a/src/handlebars/archive.handlebars
+++ b/src/handlebars/archive.handlebars
@@ -44,8 +44,9 @@
               <tr class='release-row'>
                 <td class='blue-bg'>
                   <div>
-                    <h1><a href='\{{thisGitLink}}' class='light-link' target='_blank'><var release-name>\{{thisReleaseName}}</var></a></h1>
+                    <h2><a href='\{{thisGitLink}}' class='light-link' target='_blank'><var release-name>\{{thisReleaseName}}</var></a></h2>
                     <h4><var>\{{thisReleaseDay}}</var> \{{thisReleaseMonth}} <var>\{{thisReleaseYear}}</var></h4>
+                    <h4><a href='\{{thisDashLink}}' class='light-link' target='_blank'>Download Stats</a></h4>
                   </div>
                 </td>
                 <td>

--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -51,6 +51,7 @@ function buildArchiveHTML(releases, jckJSON) {
     RELEASEOBJECT.thisReleaseMonth = publishedAt.format('MMMM');
     RELEASEOBJECT.thisReleaseYear = publishedAt.format('YYYY');
     RELEASEOBJECT.thisGitLink = eachRelease.release_link;
+    RELEASEOBJECT.thisDashLink = 'https://dash.adoptopenjdk.net/version.html?version=' + variant.replace('open','') + '&tag=' + encodeURIComponent(eachRelease.release_name);
 
     // create an array of the details for each asset that is attached to this release
     var assetArray = eachRelease.binaries;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

This PR adds a handy per release link to the new download dashboard at http://dash.adoptopenjdk.net/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
