### PR TITLE
Content loading tweaks

### DIFF
--- a/src/handlebars/archive.handlebars
+++ b/src/handlebars/archive.handlebars
@@ -22,19 +22,19 @@
       </div>
     </a>
 
-    <div id="error-container"></div>
+    <div class="btn-container">
+      <form id="jdk-selector" class="btn-form">
+        <h3>1. Choose a Version</h3>
+      </form>
+      <form id="jvm-selector" class="btn-form">
+        <h3>2. Choose a JVM</h3>
+      </form>
+    </div>
 
     <div id="loading"><img src="dist/assets/loading_dots.gif" width="40" height="40"></div>
+    <div id="error-container"></div>
 
     <div id="archive-list" class="hide">
-      <div class="btn-container">
-        <form id="jdk-selector" class="btn-form">
-          <h3>1. Choose a Version</h3>
-        </form>
-        <form id="jvm-selector" class="btn-form">
-          <h3>2. Choose a JVM</h3>
-        </form>
-      </div>
       <div id="pagination-container"></div>
       <table class='archive-container'>
         <tbody id='archive-table-body'>

--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -10,7 +10,7 @@
   </p>
 
   <div class="dl-container">
-    <h2 id="dl-text" class="animated fadeIn">Downloads</h2>
+    <h2 id="dl-text" class="invisible">Downloads</h2>
 
     <div id="error-container"></div>
 

--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -12,8 +12,6 @@
   <div class="dl-container">
     <h2 id="dl-text" class="invisible">Downloads</h2>
 
-    <div id="error-container"></div>
-
     <div class="btn-container index-btn-container">
       <form id="jdk-selector" class="jdk-btn-form btn-form">
         <h3>1. Choose a Version</h3>
@@ -37,6 +35,8 @@
     </div>
 
     <div id='loading'><img src='dist/assets/loading_dots.gif' height='40' width='40'></div>
+    <div id="error-container"></div>
+
     <a href="./releases.html" class="dl-button a-button fadeIn invisible" id="dl-latest">
       <div id="dl-version">
         <i id="dl-icon" class="fa fa-download" aria-hidden="true"></i>

--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -4,21 +4,26 @@
 
   <h1 class="large-title">Installation</h1>
 
+  <div class="align-center">
+    <div class="btn-container">
+      <form id="jdk-selector" class="btn-form">
+        <h3>1. Choose a Version</h3>
+      </form>
+      <form id="jvm-selector" class="btn-form">
+        <h3>2. Choose a JVM</h3>
+      </form>
+    </div>
+
+    <h2 class="inline-block">Platform: </h2>
+    <select id="platform-selector" style="margin-left:1rem;">
+      <option value="unknown">Select a platform</option>
+    </select>
+  </div>
+
   <div id="loading"><img src="dist/assets/loading_dots.gif" width="40" height="40"></div>
   <div id="error-container"></div>
 
   <div id="installation-container" class="info-page-container hide">
-    <div class="align-center">
-      <div class="btn-container">
-        <form id="jdk-selector" class="btn-form">
-          <h3>1. Choose a Version</h3>
-        </form>
-        <form id="jvm-selector" class="btn-form">
-          <h3>2. Choose a JVM</h3>
-        </form>
-      </div>
-      <h2 class="inline-block">Platform: </h2><select id="platform-selector" style="margin-left:1rem;"></select>
-    </div>
     <div id="installation-template">
       <script id="template" type="text/x-handlebars-template">
         \{{#each htmlTemplate}}

--- a/src/handlebars/releases.handlebars
+++ b/src/handlebars/releases.handlebars
@@ -19,11 +19,6 @@
         </div>
       </a>
 
-      <div id="loading"><img src="dist/assets/loading_dots.gif" width="40" height="40"></div>
-      <div id="error-container"></div>
-    </div>
-
-    <div id="latest-container" class="invisible">
       <div class="btn-container">
         <form id="jdk-selector" class="btn-form">
           <h3>1. Choose a Version</h3>
@@ -32,6 +27,12 @@
           <h3>2. Choose a JVM</h3>
         </form>
       </div>
+
+      <div id="loading"><img src="dist/assets/loading_dots.gif" width="40" height="40"></div>
+      <div id="error-container"></div>
+    </div>
+
+    <div id="latest-container" class="invisible">
       <h3 id="description_header"></h3>
       <a id="description_link" href=""></a>
       <h2 style="margin-bottom: 0.6rem;">Build <strong><a href="" id="latest-build-name" target="_blank"></a></strong></h2>

--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -15,14 +15,15 @@ function populateArchive() {
   loadPlatformsThenData(function () {
 
     var handleResponse = function (response) {
-      loadJSON(getRepoName(true, 'releases'), 'jck', function (response_jck) {
+      // TODO: enable this request when 'jck.json' exists.  For now the 404 just slows things down.
+      /*loadJSON(getRepoName(true, 'releases'), 'jck', function (response_jck) {
         var jckJSON = {}
         if (response_jck !== null) {
           jckJSON = JSON.parse(response_jck)
         }
         buildArchiveHTML(response, jckJSON);
-      });
-      return true;
+      });*/
+      buildArchiveHTML(response, {});
     };
 
     loadAssetInfo(variant, jvmVariant, 'releases', undefined, undefined, handleResponse, function () {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -42,14 +42,16 @@ function setDownloadSection() {
         return;
       }
 
+      // TODO: enable this request when 'jck.json' exists.  For now the 404 just slows things down.
       /* eslint-disable no-undef */
-      loadJSON(getRepoName(true, 'releases'), 'jck', function(response_jck) {
+      /*loadJSON(getRepoName(true, 'releases'), 'jck', function(response_jck) {
         var jckJSON = {}
         if (response_jck !== null) {
           jckJSON = JSON.parse(response_jck)
         }
         buildHomepageHTML(releasesJson, jckJSON, OS);
-      });
+      });*/
+      buildHomepageHTML(releasesJson, {}, OS);
     };
 
     /* eslint-disable no-undef */

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -38,22 +38,18 @@ function setDownloadSection() {
     dlText.classList.remove('invisible');
 
     var handleResponse = function (releasesJson) {
-      if (releasesJson !== null && releasesJson !== 'undefined') {
-        /* eslint-disable no-undef */
-        var repoName = getRepoName(true, 'releases');
-
-        if (typeof releasesJson !== 'undefined') { // if there are releases...
-          loadJSON(repoName, 'jck', function(response_jck) {
-            var jckJSON = {}
-            if (response_jck !== null) {
-              jckJSON = JSON.parse(response_jck)
-            }
-            buildHomepageHTML(releasesJson, jckJSON, OS);
-          });
-          return true;
-        }
+      if (!releasesJson || !releasesJson.release_name) {
+        return;
       }
-      return false;
+
+      /* eslint-disable no-undef */
+      loadJSON(getRepoName(true, 'releases'), 'jck', function(response_jck) {
+        var jckJSON = {}
+        if (response_jck !== null) {
+          jckJSON = JSON.parse(response_jck)
+        }
+        buildHomepageHTML(releasesJson, jckJSON, OS);
+      });
     };
 
     /* eslint-disable no-undef */

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -28,9 +28,17 @@ function removeRadioButtons() {
 function setDownloadSection() {
   loadPlatformsThenData(function() {
     removeRadioButtons();
+
+    // Try to match up the detected OS with a platform from 'config.json'
+    var OS = detectOS();
+
+    if (OS) {
+      dlText.innerHTML = 'Download for <var platform-name>' + OS.officialName + '</var>';
+    }
+    dlText.classList.remove('invisible');
+
     var handleResponse = function (releasesJson) {
       if (releasesJson !== null && releasesJson !== 'undefined') {
-
         /* eslint-disable no-undef */
         var repoName = getRepoName(true, 'releases');
 
@@ -40,7 +48,7 @@ function setDownloadSection() {
             if (response_jck !== null) {
               jckJSON = JSON.parse(response_jck)
             }
-            buildHomepageHTML(releasesJson, jckJSON);
+            buildHomepageHTML(releasesJson, jckJSON, OS);
           });
           return true;
         }
@@ -58,13 +66,11 @@ function setDownloadSection() {
 }
 
 /* eslint-disable no-unused-vars */
-function buildHomepageHTML(releasesJson, jckJSON) {
+function buildHomepageHTML(releasesJson, jckJSON, OS) {
   // set the download button's version number to the latest release
   dlVersionText.innerHTML = releasesJson.release_name;
 
   var assetArray = releasesJson.binaries;
-
-  var OS = detectOS(); // set a variable as an object containing all information about the user's OS (from the global.js 'platforms' array)
   var matchingFile = null;
 
   // if the OS has been detected...
@@ -116,17 +122,14 @@ function buildHomepageHTML(releasesJson, jckJSON) {
   // if there IS a matching binary for the user's OS...
   if (matchingFile) {
     dlLatest.href = matchingFile.binary_link; // set the main download button's link to be the binary's download url
-    dlText.innerHTML = ('Download for <var platform-name>' + OS.officialName + '</var>'); // set the text to be OS-specific, using the full OS name.
     var thisBinarySize = Math.floor((matchingFile.binary_size) / 1024 / 1024);
     dlVersionText.innerHTML += (' - ' + thisBinarySize + ' MB');
-
   }
   // if there is NOT a matching binary for the user's OS...
   else {
     dlOther.classList.add('hide'); // hide the 'Other platforms' button
     dlIcon.classList.add('hide'); // hide the download icon on the main button, to make it look less like you're going to get a download immediately
     dlIcon2.classList.remove('hide'); // un-hide an arrow-right icon to show instead
-    dlText.innerHTML = ('Downloads'); // change the text to be generic: 'Downloads'.
     /* eslint-disable no-undef */
     dlLatest.href = './releases.html?' + formSearchArgs('variant',variant,'jvmVariant', jvmVariant); // set the main download button's link to the latest releases page for all platforms.
   }

--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -93,20 +93,13 @@ function displayInstallPlatform() {
   if (thisPlatformInstallation) {
     platformSelector.value = platformHash;
     thisPlatformInstallation.classList.remove('hide');
-  }
-
-  else {
+  } else {
     var currentValues = [];
     var platformSelectorOptions = Array.apply(null, platformSelector.options);
     platformSelectorOptions.forEach(function (eachOption) {
       currentValues.push(eachOption.value);
     });
-    if (currentValues.indexOf('unknown') === -1) {
-      var op = new Option();
-      op.value = 'unknown';
-      op.text = 'Select a platform';
-      platformSelector.options.add(op, 0);
-    }
+
     platformSelector.value = 'unknown';
   }
 }
@@ -122,7 +115,7 @@ function unselectInstallPlatform() {
 function setInstallationPlatformSelector(thisReleasePlatforms) {
 
   if (platformSelector) {
-    if (platformSelector.options.length === 0) {
+    if (platformSelector.options.length === 1) {
       thisReleasePlatforms.forEach(function (eachPlatform) {
         var op = new Option();
         op.value = eachPlatform.thisPlatformType;

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -15,17 +15,15 @@ function populateLatest() {
   loadPlatformsThenData(function () {
 
     var handleResponse = function (response) {
-
       // create an array of the details for each asset that is attached to a release
       var assetArray = response.binaries;
 
       if (assetArray.length === 0) {
-        return false
+        return;
       }
 
-      var repoName = getRepoName(true, 'releases');
-
-      loadJSON(repoName, 'jck', function (response_jck) {
+      // TODO: enable this request when 'jck.json' exists.  For now the 404 just slows things down.
+      /*loadJSON(getRepoName(true, 'releases'), 'jck', function (response_jck) {
 
         var jckJSON = {}
         if (response_jck !== null) {
@@ -33,9 +31,8 @@ function populateLatest() {
         }
 
         buildLatestHTML(response, jckJSON, assetArray);
-      });
-
-      return true;
+      });*/
+      buildLatestHTML(response, {}, assetArray);
     };
 
     loadAssetInfo(variant, jvmVariant, 'releases', 'latest', undefined, handleResponse, function () {


### PR DESCRIPTION
The main goal of this PR is to get stuff to show up as soon as possible.  For example, the version+JVM selectors only rely on the data from `config.json`, so there's no need to wait for both an API request and (failing) `jck.json` request to complete.

This also places the error container in a consistent way (see [index](https://adoptopenjdk.net/index.html?variant=openjdk9&jvmVariant=invalid), [releases](https://adoptopenjdk.net/releases.html?variant=openjdk9&jvmVariant=invalid), [archive](https://adoptopenjdk.net/archive.html?variant=openjdk9&jvmVariant=invalid), [nightly](https://adoptopenjdk.net/nightly.html?variant=openjdk9&jvmVariant=invalid)) and ensures the selectors don't disappear on an error (see [valid](https://adoptopenjdk.net/releases.html?variant=openjdk9&jvmVariant=hotspot) vs [error](https://adoptopenjdk.net/releases.html?variant=openjdk9&jvmVariant=invalid)).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
