### PR TITLE
Add 'Array.prototype.find' polyfill

### DIFF
--- a/src/js/nightly.js
+++ b/src/js/nightly.js
@@ -108,6 +108,7 @@ function buildNightlyHTML(files) {
     var nameOfFile = (eachAsset.binary_name);
     var uppercaseFilename = nameOfFile.toUpperCase(); // make the name of the file uppercase
     NIGHTLYOBJECT.thisPlatform = findPlatform(eachAsset); // get the searchableName, e.g. MAC or X64_LINUX.
+    // We don't use includes because IE doesn't support it well, hence we use indexOf instead
     var type = nameOfFile.indexOf('-jre') !== -1 ? 'jre' : 'jdk';
 
     // secondly, check if the file has the expected file extension for that platform...

--- a/src/js/nightly.js
+++ b/src/js/nightly.js
@@ -108,7 +108,7 @@ function buildNightlyHTML(files) {
     var nameOfFile = (eachAsset.binary_name);
     var uppercaseFilename = nameOfFile.toUpperCase(); // make the name of the file uppercase
     NIGHTLYOBJECT.thisPlatform = findPlatform(eachAsset); // get the searchableName, e.g. MAC or X64_LINUX.
-    var type = nameOfFile.includes('-jre') ? 'jre' : 'jdk';
+    var type = nameOfFile.indexOf('-jre') !== -1 ? 'jre' : 'jdk';
 
     // secondly, check if the file has the expected file extension for that platform...
     // (this filters out all non-binary attachments, e.g. SHA checksums - these contain the platform name, but are not binaries)

--- a/src/js/polyfill/Array.prototype.find.js
+++ b/src/js/polyfill/Array.prototype.find.js
@@ -1,0 +1,46 @@
+// https://tc39.github.io/ecma262/#sec-array.prototype.find
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+     // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return undefined.
+      return undefined;
+    },
+    configurable: true,
+    writable: true
+  });
+}

--- a/src/js/polyfill/Array.prototype.find.js
+++ b/src/js/polyfill/Array.prototype.find.js
@@ -1,4 +1,6 @@
+// Freely copied, see https://developer.mozilla.org/en-US/docs/MDN/About#Copyrights_and_licenses 
 // https://tc39.github.io/ecma262/#sec-array.prototype.find
+// We have this due to IE not supporting Array.prototype.find correctly
 if (!Array.prototype.find) {
   Object.defineProperty(Array.prototype, 'find', {
     value: function(predicate) {


### PR DESCRIPTION
The Releases page redo included a call to [`Array.prototype.find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), which IE doesn't like.  This adds a polyfill to get it working again.

Another option would be to include [`@babel/polyfill`](https://babeljs.io/docs/en/babel-polyfill) to avoid worrying about specific polyfills.

*edit:* I've added a small fix for the Nightly page, since IE also doesn't like [`String.prototype.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
