### PR TITLE
Rename 'Hotspot' to 'HotSpot'

### DIFF
--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -24,8 +24,8 @@
               <h4>Choosing the right JVM</h4>
             </div>
             <div class="popup-text">
-              <p class="hotspot-text"><b>Hotspot</b> is the VM from the OpenJDK community. It is the most widely used VM today and is used in Oracle’s JDK. It is suitable for all workloads.</p>
-              <p>For more details see <a target="_blank" href="https://openjdk.java.net/groups/hotspot/">OpenJDK Hotspot</a>.</p>
+              <p class="hotspot-text"><b>HotSpot</b> is the VM from the OpenJDK community. It is the most widely used VM today and is used in Oracle’s JDK. It is suitable for all workloads.</p>
+              <p>For more details see <a target="_blank" href="https://openjdk.java.net/groups/hotspot/">OpenJDK HotSpot</a>.</p>
               <p class="openj9-text"><b>OpenJ9</b> is the VM from the Eclipse community.  It is an enterprise-grade VM designed for low memory usage and fast start-up and is used in IBM’s JDK.  It is also suitable for running all workloads.</p>
               <p>For more details see <a target="_blank" href="https://www.eclipse.org/openj9/">Eclipse OpenJ9</a>.</p>
             </div>

--- a/src/json/config.json
+++ b/src/json/config.json
@@ -2,8 +2,8 @@
   "variants": [
     {
       "searchableName": "openjdk8-hotspot",
-      "officialName": "OpenJDK 8 with Hotspot",
-      "jvm": "Hotspot",
+      "officialName": "OpenJDK 8 with HotSpot",
+      "jvm": "HotSpot",
       "label": "OpenJDK 8",
       "lts": true,
       "default": true
@@ -19,8 +19,8 @@
     },
     {
       "searchableName": "openjdk9-hotspot",
-      "officialName": "OpenJDK 9 with Hotspot",
-      "jvm": "Hotspot",
+      "officialName": "OpenJDK 9 with HotSpot",
+      "jvm": "HotSpot",
       "label": "OpenJDK 9",
       "lts": false
     },
@@ -35,8 +35,8 @@
     },
     {
       "searchableName": "openjdk10-hotspot",
-      "officialName": "OpenJDK 10 with Hotspot",
-      "jvm": "Hotspot",
+      "officialName": "OpenJDK 10 with HotSpot",
+      "jvm": "HotSpot",
       "label": "OpenJDK 10",
       "lts": false
     },
@@ -51,8 +51,8 @@
     },
     {
       "searchableName": "openjdk11-hotspot",
-      "officialName": "OpenJDK 11 with Hotspot",
-      "jvm": "Hotspot",
+      "officialName": "OpenJDK 11 with HotSpot",
+      "jvm": "HotSpot",
       "label": "OpenJDK 11",
       "lts": true
     },

--- a/src/json/config.schema.json
+++ b/src/json/config.schema.json
@@ -48,7 +48,7 @@
             "type": "string",
             "title": "Official name",
             "description": "Descriptive name that includes OpenJDK and JVM versions.",
-            "examples": ["OpenJDK 8 with Hotspot", "OpenJDK 11 with Eclipse OpenJ9"]
+            "examples": ["OpenJDK 8 with HotSpot", "OpenJDK 11 with Eclipse OpenJ9"]
           },
           "default": {
             "$id": "#/properties/variants/items/properties/default",


### PR DESCRIPTION
The spelling of Oracle's VM in OpenJDK is 'HotSpot' instead of 'Hotspot'.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)