### PR TITLE
Inline the logo to prevent alt text flash, minor `gulpfile.js` tweaks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,9 @@ gulp.task('watch', function() {
   gulp.watch('./src/scss/*.scss', function() {
     runSequence('styles','inject', browserSync.reload);
   });
-  gulp.watch(['./src/assets/*.jp*', './src/assets/*.png', './src/assets/*.svg', './src/assets/*.gif'], ['images']);
+  gulp.watch(['./src/assets/*.jp*', './src/assets/*.png', './src/assets/*.svg', './src/assets/*.gif'], () => {
+    runSequence('images','handlebars', browserSync.reload);
+  });
   gulp.watch('./src/assets/*.ico', ['icon']);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -136,12 +136,12 @@ gulp.task('styles', () => {
 
 // inject task
 gulp.task('inject', () => {
-  var options = {
+  const options = {
     relative: true,
     addPrefix: '.'
   };
-  var sourceFiles = gulp.src(['./dist/js/app.min-*.js', './dist/css/styles.min-*.css'], {read: false});
-  var targetFiles = gulp.src('./*.html');
+  const sourceFiles = gulp.src(['./dist/js/app.min-*.js', './dist/css/styles.min-*.css'], {read: false});
+  const targetFiles = gulp.src('./*.html');
 
   return targetFiles.pipe(inject(sourceFiles, options)) // injects the latest minified JS and CSS into all HTML files
   .pipe(gulp.dest('./'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,17 +22,18 @@ const inject = require('gulp-inject');
 const robots = require('gulp-robots');
 const clean = require('gulp-clean');
 const babel = require('gulp-babel');
+const base64img = require('base64-img');
 
 const sourceFiles = ['./node_modules/underscore/underscore.js', './src/js/**/*.js'];
 
 // default task
 gulp.task('default', function() {
-  runSequence('clean','json-validate',['handlebars','json','scripts','styles','images','icon'],'inject','watch','browser-sync');
+  runSequence('clean','json-validate',['json','scripts','styles','images','icon'],'handlebars','inject','watch','browser-sync');
 });
 
 // build task
 gulp.task('build', function() {
-  runSequence('clean',['handlebars','json','scripts','styles','images','icon'],'inject','sitemap','robots','lint');
+  runSequence('clean',['json','scripts','styles','images','icon'],'handlebars','inject','sitemap','robots','lint');
 });
 
 // clean task (deletes /dist dir)
@@ -61,11 +62,12 @@ gulp.task('watch', function() {
 
 // Handlebars HTML build task
 gulp.task('handlebars', function () {
-  var templateData = {
-  },
-  options = {
-    batch : ['./src/handlebars/partials']
-  }
+  const templateData = {};
+
+  const options = {
+    batch: ['./src/handlebars/partials'],
+    helpers: {base64img: base64img.base64Sync}
+  };
 
   return gulp.src('./src/handlebars/*.handlebars')
     .pipe(handlebars(templateData, options))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,33 +27,30 @@ const base64img = require('base64-img');
 const sourceFiles = ['./node_modules/underscore/underscore.js', './src/js/**/*.js'];
 
 // default task
-gulp.task('default', function() {
+gulp.task('default', () => {
   runSequence('clean','json-validate',['json','scripts','styles','images','icon'],'handlebars','inject','watch','browser-sync');
 });
 
 // build task
-gulp.task('build', function() {
+gulp.task('build', () => {
   runSequence('clean',['json','scripts','styles','images','icon'],'handlebars','inject','sitemap','robots','lint');
 });
 
 // clean task (deletes /dist dir)
-gulp.task('clean', function () {
-  return gulp.src('dist', {read: false})
-    .pipe(clean());
-});
+gulp.task('clean', () => gulp.src('dist', {read: false}).pipe(clean()));
 
 // watch task
-gulp.task('watch', function() {
-  gulp.watch(['./src/handlebars/partials/*.handlebars', './src/handlebars/*.handlebars'], function() {
+gulp.task('watch', () => {
+  gulp.watch(['./src/handlebars/partials/*.handlebars', './src/handlebars/*.handlebars'], () => {
     runSequence('handlebars','inject', browserSync.reload);
   });
-  gulp.watch('./src/json/*.json', function() {
+  gulp.watch('./src/json/*.json', () => {
     runSequence('json', browserSync.reload);
   });
-  gulp.watch('./src/js/**/*.js', function() {
+  gulp.watch('./src/js/**/*.js', () => {
     runSequence('scripts','inject', browserSync.reload);
   });
-  gulp.watch('./src/scss/*.scss', function() {
+  gulp.watch('./src/scss/*.scss', () => {
     runSequence('styles','inject', browserSync.reload);
   });
   gulp.watch(['./src/assets/*.jp*', './src/assets/*.png', './src/assets/*.svg', './src/assets/*.gif'], () => {
@@ -63,7 +60,7 @@ gulp.task('watch', function() {
 });
 
 // Handlebars HTML build task
-gulp.task('handlebars', function () {
+gulp.task('handlebars', () => {
   const templateData = {};
 
   const options = {
@@ -81,13 +78,10 @@ gulp.task('handlebars', function () {
 });
 
 // json task
-gulp.task('json', function() {
-  return gulp.src('./src/json/*.json')
-    .pipe(gulp.dest('./dist/json/'));
-});
+gulp.task('json', () => gulp.src('./src/json/*.json').pipe(gulp.dest('./dist/json/')));
 
 // scripts task
-gulp.task('scripts', function() {
+gulp.task('scripts', () => {
   return gulp.src(sourceFiles)
     .pipe(babel({
       presets: [['@babel/env', {
@@ -115,7 +109,7 @@ gulp.task('scripts', function() {
 });
 
 // styles task
-gulp.task('styles', function() {
+gulp.task('styles', () => {
   return gulp.src('./src/scss/*.scss')
     .pipe(sass())
     .on('error', gutil.log)
@@ -141,7 +135,7 @@ gulp.task('styles', function() {
 });
 
 // inject task
-gulp.task('inject', function() {
+gulp.task('inject', () => {
   var options = {
     relative: true,
     addPrefix: '.'
@@ -154,7 +148,7 @@ gulp.task('inject', function() {
 });
 
 // images task
-gulp.task('images', function() {
+gulp.task('images', () => {
   return gulp.src(['./src/assets/*.jp*', './src/assets/*.png',  './src/assets/*.svg', './src/assets/*.gif'])
     .pipe(imagemin())
     .on('error', gutil.log)
@@ -162,13 +156,13 @@ gulp.task('images', function() {
 });
 
 // icon task
-gulp.task('icon', function() {
+gulp.task('icon', () => {
   return gulp.src('./src/assets/*.ico')
     .pipe(gulp.dest('./dist/assets/'));
 });
 
 // json validation task
-gulp.task('json-validate', function () {
+gulp.task('json-validate', () => {
   gutil.log('Validating config.json against config.schema.json');
 
   const objFromJson = (uri) => JSON.parse(fs.readFileSync(uri, 'utf-8'));
@@ -190,7 +184,7 @@ gulp.task('json-validate', function () {
 });
 
 // lint task
-gulp.task('lint', function() {
+gulp.task('lint', () => {
   return gulp.src('./dist/js/app.js')
     .pipe(eslint())
     .pipe(eslint.format())
@@ -198,7 +192,7 @@ gulp.task('lint', function() {
 });
 
 // sitemap task
-gulp.task('sitemap', function () {
+gulp.task('sitemap', () => {
   gulp.src(['./*.html', '!./banner.html'], {
       read: false
     })
@@ -209,7 +203,7 @@ gulp.task('sitemap', function () {
 });
 
 // browser-sync task
-gulp.task('browser-sync', function() {
+gulp.task('browser-sync', () => {
     browserSync.init({
         server: {
             baseDir: './'
@@ -219,7 +213,7 @@ gulp.task('browser-sync', function() {
 });
 
 // robots task
-gulp.task('robots', function () {
+gulp.task('robots', () => {
   gulp.src('index.html')
     .pipe(robots({
       useragent: '*',

--- a/package-lock.json
+++ b/package-lock.json
@@ -993,6 +993,16 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
+    "ajax-request": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ajax-request/-/ajax-request-1.2.3.tgz",
+      "integrity": "sha1-mfy+wdbSeS+F+pSVNTMr0U9fN5A=",
+      "dev": true,
+      "requires": {
+        "file-system": "2.2.2",
+        "utils-extend": "1.0.8"
+      }
+    },
     "ajv": {
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
@@ -1419,6 +1429,16 @@
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
+    },
+    "base64-img": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/base64-img/-/base64-img-1.0.4.tgz",
+      "integrity": "sha1-PiLVXWx0okVT2EDSsbwSp9sHjTU=",
+      "dev": true,
+      "requires": {
+        "ajax-request": "1.2.3",
+        "file-system": "2.2.2"
+      }
     },
     "base64-js": {
       "version": "0.0.8",
@@ -3821,6 +3841,25 @@
       "requires": {
         "flat-cache": "1.3.2",
         "object-assign": "4.1.1"
+      }
+    },
+    "file-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
+      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
+      "dev": true,
+      "requires": {
+        "utils-extend": "1.0.8"
+      }
+    },
+    "file-system": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
+      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
+      "dev": true,
+      "requires": {
+        "file-match": "1.0.2",
+        "utils-extend": "1.0.8"
       }
     },
     "file-type": {
@@ -13660,6 +13699,12 @@
         "define-properties": "1.1.3",
         "object.getownpropertydescriptors": "2.0.3"
       }
+    },
+    "utils-extend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
+      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@babel/core": "^7.1.5",
     "@babel/preset-env": "^7.1.5",
     "ajv": "^6.5.5",
+    "base64-img": "^1.0.4",
     "browser-sync": "^2.26.3",
     "chai": "^4.2.0",
     "eslint": "^5.9.0",

--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -73,7 +73,7 @@
   <nav>
       <i id="menu-button" class="fa fa-bars" aria-hidden="true"></i>
       <a id="logo" href="./index.html" class="a-button">
-          <div><img src="dist/assets/squares-logo.png" alt="AdoptOpenJDK six-square logo"></div>
+          <div><img src="{{base64img 'dist/assets/squares-logo.png'}}" alt="AdoptOpenJDK six-square logo"></div>
           <div><span>AdoptOpenJDK</span></div>
       </a>
 


### PR DESCRIPTION
This PR introduces the `base64img` Handlebars helper, which converts images to their base64 representation, and uses it to address the 0.12KB logo's `alt` text flash/flicker (["AdoptOpenJDK six-square logo"](/AdoptOpenJDK/openjdk-website/blob/24cfba91d21e036eb3fc0acbe3a8e8f442e4084d/src/handlebars/partials/header.handlebars#L76)) that occurs on page loads.

It also switches `gulpfile.js` to arrow functions and replaces `var` with `const`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
