### PR TITLE
Remove unnecessary complexity for the site banner/notice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,9 @@ The website's JavaScript then uses a GET request to access these `.json` files, 
 * When you insert the footer partial into a `.handlebars` file, you can pass in a variable for any page-specific JavaScript that you have written to be run 'on page load', e.g. `{{> footer script='<script>onIndexLoad();</script>' }}`. See the 'JS' section below for details on this system.
 * If you are unsure, it is best to begin by copying an existing `.handlebars` file, and deleting the content between the `<main>` tags.
 
+### Global banner
+* If you need to insert a banner/notification on all pages, edit the commented-out section at the end of `/src/handlebars/partials/header.handlebars`.
+
 ### Menu system
 * The menu contents can be changed in `/src/handlebars/partials/menu.handlebars`.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -193,7 +193,7 @@ gulp.task('lint', () => {
 
 // sitemap task
 gulp.task('sitemap', () => {
-  gulp.src(['./*.html', '!./banner.html'], {
+  gulp.src('./*.html', {
       read: false
     })
     .pipe(sitemap({
@@ -218,7 +218,7 @@ gulp.task('robots', () => {
     .pipe(robots({
       useragent: '*',
       allow: ['/'],
-      disallow: ['/404.html', '/banner.html', '/dist']
+      disallow: ['/404.html', '/dist']
     }))
     .pipe(gulp.dest('./'));
 });

--- a/src/handlebars/banner.handlebars
+++ b/src/handlebars/banner.handlebars
@@ -1,7 +1,0 @@
-<!-- This is where you can add banners to the website -->
-  <!--
-  <div class="alert align-center">
-   <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
-    <strong>4th Oct 2018:</strong>&nbsp;&nbsp; AdoptOpenJDK <strong>Java 11</strong> has been released!&nbsp;&nbsp; AdoptOpenJDK <strong>Java 1.8.0_181</strong> is coming soon.
-  </div>
-  -->

--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -24,7 +24,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
     {{{style1}}}
     {{{style2}}}
-    <script src="https://www.w3schools.com/lib/w3data.js"></script>
 </head>
 
 <script type="application/ld+json">
@@ -80,7 +79,10 @@
       <div id="header-social-bar">{{> social-bar }}</div>
   </nav>
 
-  <div w3-include-html="./banner.html"></div>
-  <script>
-      w3IncludeHTML();
-  </script>
+<!-- This is where you can add banners to the website -->
+<!--
+<div class="alert align-center">
+<span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
+<strong>4th Oct 2018:</strong>&nbsp;&nbsp; AdoptOpenJDK <strong>Java 11</strong> has been released!&nbsp;&nbsp; AdoptOpenJDK <strong>Java 1.8.0_181</strong> is coming soon.
+</div>
+-->


### PR DESCRIPTION
This PR simplifies things by inserting the banner/notice at build time, rather than on each client page load via https://www.w3schools.com/lib/w3data.js.  There is no benefit to dynamically loading `banner.html` on every page when Prod changes occur through PRs / Jenkins builds.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
