### PR TITLE
Fix menu twisties and centralize global assignments in 'entry.js'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1042,8 +1042,8 @@
       "integrity": "sha1-mfy+wdbSeS+F+pSVNTMr0U9fN5A=",
       "dev": true,
       "requires": {
-        "file-system": "2.2.2",
-        "utils-extend": "1.0.8"
+        "file-system": "^2.1.1",
+        "utils-extend": "^1.0.7"
       }
     },
     "ajv": {
@@ -1540,8 +1540,8 @@
       "integrity": "sha1-PiLVXWx0okVT2EDSsbwSp9sHjTU=",
       "dev": true,
       "requires": {
-        "ajax-request": "1.2.3",
-        "file-system": "2.2.2"
+        "ajax-request": "^1.2.0",
+        "file-system": "^2.1.0"
       }
     },
     "base64-js": {
@@ -4408,7 +4408,7 @@
       "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
       "dev": true,
       "requires": {
-        "utils-extend": "1.0.8"
+        "utils-extend": "^1.0.6"
       }
     },
     "file-system": {
@@ -4417,8 +4417,8 @@
       "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
       "dev": true,
       "requires": {
-        "file-match": "1.0.2",
-        "utils-extend": "1.0.8"
+        "file-match": "^1.0.1",
+        "utils-extend": "^1.0.4"
       }
     },
     "file-type": {
@@ -4759,12 +4759,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4779,12 +4781,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4906,7 +4910,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4918,6 +4923,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4932,6 +4938,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5043,7 +5050,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5176,6 +5184,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/handlebars/partials/footer.handlebars
+++ b/src/handlebars/partials/footer.handlebars
@@ -38,7 +38,7 @@
 {{{script3}}}
 {{{script4}}}
 
-<script>persistUrlQuery();</script>
+<script>persistUrlQuery(); buildMenuTwisties();</script>
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -212,19 +212,21 @@ module.exports.loadPlatformsThenData = (callback) => {
 }
 
 // build the menu twisties
-const submenus = document.getElementById('menu-content').getElementsByClassName('submenu');
+module.exports.buildMenuTwisties = () => {
+  const submenus = document.getElementById('menu-content').getElementsByClassName('submenu');
 
-for (let i = 0; i < submenus.length; i++) {
-  const twisty = document.createElement('span');
-  const twistyContent = document.createTextNode('>');
-  twisty.appendChild(twistyContent);
-  twisty.className = 'twisty';
+  for (let i = 0; i < submenus.length; i++) {
+    const twisty = document.createElement('span');
+    const twistyContent = document.createTextNode('>');
+    twisty.appendChild(twistyContent);
+    twisty.className = 'twisty';
 
-  const thisLine = submenus[i].getElementsByTagName('a')[0];
-  thisLine.appendChild(twisty);
+    const thisLine = submenus[i].getElementsByTagName('a')[0];
+    thisLine.appendChild(twisty);
 
-  thisLine.onclick = function () {
-    this.parentNode.classList.toggle('open');
+    thisLine.onclick = function () {
+      this.parentNode.classList.toggle('open');
+    }
   }
 }
 
@@ -263,7 +265,7 @@ function getQueryByName(name) {
   return decodeURIComponent(results[2].replace(/\+/g, ' '));
 }
 
-global.persistUrlQuery = () => {
+module.exports.persistUrlQuery = () => {
   const links = Array.from(document.getElementsByTagName('a'));
   const link = (window.location.hostname !== 'localhost' ? 'https://' : '') + window.location.hostname;
 
@@ -353,7 +355,7 @@ function setRadioSelectors() {
   }
 }
 
-global.copyClipboard = (elementSelector) => {
+module.exports.copyClipboard = (elementSelector) => {
   const input = document.createElement('input');
   input.value = document.querySelector(elementSelector).textContent;
 

--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -3,3 +3,9 @@ global.onArchiveLoad = require('./archive').onArchiveLoad;
 global.onInstallationLoad = require('./installation').onInstallationLoad;
 global.onNightlyLoad = require('./nightly').onNightlyLoad;
 global.onLatestLoad = require('./releases').onLatestLoad;
+
+const {buildMenuTwisties, copyClipboard, persistUrlQuery} = require('./common');
+Object.assign(global, {buildMenuTwisties, copyClipboard, persistUrlQuery});
+
+const {selectLatestPlatform, unselectLatestPlatform} = require('./releases');
+Object.assign(global, {selectLatestPlatform, unselectLatestPlatform});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -33,7 +33,7 @@ module.exports.onIndexLoad = () => {
       buildHomepageHTML(releasesJson, {}, OS);
     };
 
-    loadAssetInfo(variant, jvmVariant, 'releases', 'latest', undefined, handleResponse, function () {
+    loadAssetInfo(variant, jvmVariant, 'releases', 'latest', undefined, handleResponse, () => {
       errorContainer.innerHTML = `<p>There are no releases available for ${variant} on the ${jvmVariant} JVM.
         Please check our <a href='nightly.html?variant=${variant}&jvmVariant=${jvmVariant}' target='blank'>Nightly Builds</a>.</p>`;
       loading.innerHTML = ''; // remove the loading dots

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -114,11 +114,11 @@ function displayLatestPlatform() {
   }
 }
 
-global.selectLatestPlatform = (thisPlatform) => {
+module.exports.selectLatestPlatform = (thisPlatform) => {
   window.location.hash = thisPlatform.toLowerCase();
 }
 
-const unselectLatestPlatform = global.unselectLatestPlatform = (keephash) => {
+const unselectLatestPlatform = module.exports.unselectLatestPlatform = (keephash) => {
   if (!keephash) {
     history.pushState('', document.title, window.location.pathname + window.location.search);
   }


### PR DESCRIPTION
This PR fixes submenus and moves some lingering `global` assignments into `entry.js`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
