### PR TITLE
fix sponsors page

### DIFF
--- a/src/scss/styles-7-support.scss
+++ b/src/scss/styles-7-support.scss
@@ -13,7 +13,7 @@ main .support h2 {
     padding-top: 0px;
 }
 
-.support table, th, td {
+.support table, .support th, .support td {
     border: 1px solid black;
     padding-left: 1rem;
     padding-right: 1rem;


### PR DESCRIPTION
fixes a bug which was introduced in https://github.com/AdoptOpenJDK/openjdk-website/commit/8df2bf9226bfe6ae4510dc6c17195b3f675ee3c3 which added a border to every `td` on the website