### PR TITLE
Rework Archive page (Installer+JDK+JRE support)

### DIFF
--- a/src/handlebars/archive.handlebars
+++ b/src/handlebars/archive.handlebars
@@ -38,67 +38,40 @@
       <div id="pagination-container"></div>
       <table class='archive-container'>
         <tbody id='archive-table-body'>
-          <!-- BEGIN HANDLEBARS LIVE-RENDERED TEMPLATE -->
           <script id="template" type="text/x-handlebars-template">
-            \{{#each htmlTemplate}}
+            {{! For each release... }}
+            \{{#each releases}}
               <tr class='release-row'>
-                <td class='blue-bg'>
+                <td class='blue-bg release-info'>
                   <div>
-                    <h2><a href='\{{thisGitLink}}' class='light-link' target='_blank'><var release-name>\{{thisReleaseName}}</var></a></h2>
-                    <h4><var>\{{thisReleaseDay}}</var> \{{thisReleaseMonth}} <var>\{{thisReleaseYear}}</var></h4>
-                    <h4><a href='\{{thisDashLink}}' class='light-link' target='_blank'>Download Stats</a></h4>
+                    <h2><a href='\{{release_link}}' class='light-link' target='_blank'><var release-name>\{{release_name}}</var></a></h2>
+                    <h4><var>\{{release_day}}</var> \{{release_month}} <var>\{{release_year}}</var></h4>
+                    <h4><a href='\{{dashboard_link}}' class='light-link' target='_blank'>Download Stats</a></h4>
                   </div>
                 </td>
                 <td>
-
                   <table class='archive-platforms'>
-                    <tr class='column-names'>
-                      <td>
-                      </td>
-                      \{{#if installersExist}}
-                      <td>
-                        <span>Installer</span>
-                      </td>
-                      \{{/if}}
-                      \{{#if binariesExist}}
-                      <td>
-                        <span>Binary</span>
-                      </td>
-                      \{{/if}}
-                    </tr>
-
-                    \{{#each thisPlatformAssets}}
-                      <tr class='platform-row \{{thisPlatform}}'>
-                        <td>\{{thisOfficialName}}</td>
-                        \{{#if ../installersExist}}
-                        <td class='download-td'>
-                          \{{#if thisInstallerExists}}
-                          <a class='blue-button no-underline' href='\{{thisInstallerLink}}'><var binary-info>\{{thisInstallerExtension}} (\{{thisInstallerSize}} MB)</var>
-                            {{> jck-tick }}
-                          </a>
+                    {{! For each of the release's platforms with assets to display... }}
+                    \{{#each platforms}}
+                      \{{#each assets}}
+                        <tr class='platform-row'>
+                          \{{#if @first}}
+                            <td>\{{../official_name}}</td>
                           \{{else}}
-                          <div class='empty-download'>&nbsp;</div>
+                            <td></td>
                           \{{/if}}
-                        </td>
-                        \{{/if}}
-
-                        \{{#if thisBinaryExists}}
-                        <td class='download-td'>
-                          <a class='grey-button no-underline' href='\{{thisBinaryLink}}'><var binary-info>\{{thisBinaryExtension}} (\{{thisBinarySize}} MB)</var>
-                            {{> jck-tick }}
-                          </a>
-                        </td>
-                        <td><a href='\{{thisChecksumLink}}' class='dark-link'>Checksum</a></td>
-                        \{{/if}}
-                      </tr>
+                          <td class='download-td'>
+                            <a class='blue-button no-underline' href='\{{link}}'><var binary-info>\{{type}} (\{{size}} MB)</var></a>
+                          </td>
+                          <td><a href='\{{checksum_link}}' class='dark-link'>Checksum</a></td>
+                        </tr>
+                      \{{/each}}
                     \{{/each}}
                   </table>
                 </td>
               </tr>
             \{{/each}}
           </script>
-          <!-- END HANDLEBARS LIVE-RENDERED TEMPLATE -->
-
         </tbody>
       </table>
     </div>

--- a/src/js/archive.js
+++ b/src/js/archive.js
@@ -1,5 +1,5 @@
 const {findPlatform, getBinaryExt, getInstallerExt, getOfficialName, getPlatformOrder,
-  loadAssetInfo, orderPlatforms, setRadioSelectors, setTickLink} = require('./common');
+  loadAssetInfo, setRadioSelectors, sortByProperty} = require('./common');
 const {jvmVariant, variant} = require('./common');
 
 const loading = document.getElementById('loading');
@@ -18,128 +18,76 @@ module.exports.load = () => {
   });
 }
 
-function buildArchiveHTML(releases, jckJSON = {}) {
-  const RELEASEARRAY = [];
+function buildArchiveHTML(aReleases) {
+  const releases = [];
 
-  for (let i = 0; i<releases.length; i++) {
-    const ASSETARRAY = [];
-    const RELEASEOBJECT = {};
-    const eachRelease = releases[i];
+  aReleases.forEach(aRelease => {
+    const publishedAt = moment(aRelease.timestamp);
 
-    // set values for this release, ready to inject into HTML
-    const publishedAt = moment(eachRelease.timestamp);
-    RELEASEOBJECT.thisReleaseName = eachRelease.release_name;
-    RELEASEOBJECT.thisReleaseDate = publishedAt.toDate();
-    RELEASEOBJECT.thisReleaseDay = publishedAt.format('D');
-    RELEASEOBJECT.thisReleaseMonth = publishedAt.format('MMMM');
-    RELEASEOBJECT.thisReleaseYear = publishedAt.format('YYYY');
-    RELEASEOBJECT.thisGitLink = eachRelease.release_link;
-    RELEASEOBJECT.thisDashLink = `https://dash.adoptopenjdk.net/version.html?version=${variant.replace('open','')}`
-      + `&tag=${encodeURIComponent(eachRelease.release_name)}`;
+    const release = {
+      release_name: aRelease.release_name,
+      release_link: aRelease.release_link,
+      dashboard_link: `https://dash.adoptopenjdk.net/version.html?version=${variant.replace('open','')}`
+        + `&tag=${encodeURIComponent(aRelease.release_name)}`,
 
-    // create an array of the details for each asset that is attached to this release
-    const assetArray = eachRelease.binaries;
+      release_day: publishedAt.format('D'),
+      release_month: publishedAt.format('MMMM'),
+      release_year: publishedAt.format('YYYY'),
+
+      platforms: {},
+    };
 
     // populate 'platformTableRows' with one row per binary for this release...
-    assetArray.forEach((eachAsset) => {
-      const ASSETOBJECT = {};
-      const uppercaseFilename = eachAsset.binary_name.toUpperCase(); // make the name of the asset uppercase
+    aRelease.binaries.forEach(aReleaseAsset => {
+      const platform = findPlatform(aReleaseAsset);
 
-      ASSETOBJECT.thisPlatform = findPlatform(eachAsset);
+      // Skip this asset if its platform could not be matched (see the website's 'config.json')
+      if (!platform) {
+        return;
+      }
 
-      // firstly, check if the platform name is recognised...
-      if (ASSETOBJECT.thisPlatform) {
-        // if the filename contains both the platform name and the matching INSTALLER extension, add the relevant info to the asset object
-        ASSETOBJECT.thisInstallerExtension = getInstallerExt(ASSETOBJECT.thisPlatform);
+      // Skip this asset if it's not a binary type we're interested in displaying
+      const binary_type = aReleaseAsset.binary_type.toUpperCase();
+      if (!['INSTALLER', 'JDK', 'JRE'].includes(binary_type)) {
+        return;
+      }
 
-        ASSETOBJECT.thisBinaryExtension = getBinaryExt(ASSETOBJECT.thisPlatform); // get the file extension associated with this platform
-
-        if (uppercaseFilename.includes(ASSETOBJECT.thisInstallerExtension.toUpperCase())) {
-          if (ASSETARRAY.length) {
-            ASSETARRAY.forEach((asset) => {
-              if (asset.thisPlatform === ASSETOBJECT.thisPlatform) {
-                ASSETARRAY.pop();
-              }
-            });
-          }
-          ASSETOBJECT.thisPlatformExists = true;
-          ASSETOBJECT.thisInstallerExists = true;
-          RELEASEOBJECT.installersExist = true;
-          ASSETOBJECT.thisInstallerLink = eachAsset.binary_link;
-          ASSETOBJECT.thisInstallerSize = Math.floor((eachAsset.binary_size) / 1024 / 1024);
-          ASSETOBJECT.thisOfficialName = getOfficialName(ASSETOBJECT.thisPlatform);
-          ASSETOBJECT.thisBinaryExists = true;
-          RELEASEOBJECT.binariesExist = true;
-          ASSETOBJECT.thisBinaryLink = eachAsset.binary_link.replace(ASSETOBJECT.thisInstallerExtension, ASSETOBJECT.thisBinaryExtension);
-          ASSETOBJECT.thisBinarySize = Math.floor((eachAsset.binary_size) / 1024 / 1024);
-          ASSETOBJECT.thisChecksumLink = eachAsset.checksum_link;
-
-          ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
-          if (Object.keys(jckJSON).length === 0) {
-            ASSETOBJECT.thisVerified = false;
-          } else {
-            if (jckJSON[eachRelease.release_name] && jckJSON[eachRelease.release_name].hasOwnProperty(ASSETOBJECT.thisPlatform)) {
-              ASSETOBJECT.thisVerified = true;
-            } else {
-              ASSETOBJECT.thisVerified = false;
-            }
-            ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
-          }
-        }
-
-        // secondly, check if the file has the expected file extension for that platform...
-        // (this filters out all non-binary attachments, e.g. SHA checksums - these contain the platform name, but are not binaries)
-
-        if (uppercaseFilename.includes(ASSETOBJECT.thisBinaryExtension.toUpperCase())) {
-          let installerExist = false;
-          if (ASSETARRAY.length) {
-            ASSETARRAY.forEach((asset) => {
-              if (asset.thisPlatform === ASSETOBJECT.thisPlatform) {
-                installerExist = true;
-              }
-            });
-          }
-
-          if (!installerExist) {
-            // set values ready to be injected into the HTML
-            ASSETOBJECT.thisPlatformExists = true;
-            ASSETOBJECT.thisBinaryExists = true;
-            RELEASEOBJECT.binariesExist = true;
-            ASSETOBJECT.thisOfficialName = getOfficialName(ASSETOBJECT.thisPlatform);
-            ASSETOBJECT.thisBinaryLink = (eachAsset.binary_link);
-            ASSETOBJECT.thisBinarySize = Math.floor((eachAsset.binary_size) / 1024 / 1024);
-            ASSETOBJECT.thisChecksumLink = eachAsset.checksum_link;
-            ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
-            if (Object.keys(jckJSON).length === 0) {
-              ASSETOBJECT.thisVerified = false;
-            } else {
-              if (jckJSON[eachRelease.release_name] && jckJSON[eachRelease.release_name].hasOwnProperty(ASSETOBJECT.thisPlatform)) {
-                ASSETOBJECT.thisVerified = true;
-              } else {
-                ASSETOBJECT.thisVerified = false;
-              }
-            }
-          }
-        }
-
-        if (ASSETOBJECT.thisPlatformExists) {
-          ASSETARRAY.push(ASSETOBJECT);
+      if (!release.platforms[platform]) {
+        release.platforms[platform] = {
+          official_name: getOfficialName(platform),
+          ordinal: getPlatformOrder(platform),
+          assets: [],
         }
       }
+
+      release.platforms[platform].assets.push({
+        type: binary_type,
+        extension: 'INSTALLER' === binary_type ? getInstallerExt(platform) : getBinaryExt(platform),
+        size: Math.floor(aReleaseAsset.binary_size / 1024 / 1024),
+
+        link: aReleaseAsset.binary_link,
+        checksum_link: aReleaseAsset.checksum_link,
+      });
     });
 
-    RELEASEOBJECT.thisPlatformAssets = orderPlatforms(ASSETARRAY);
-    RELEASEARRAY.push(RELEASEOBJECT);
-  }
+    Object.values(release.platforms).forEach(aPlatform => {
+      sortByProperty(aPlatform.assets, 'type');
+    });
 
-  // Sort releases by date/timestamp in descending order
-  RELEASEARRAY.sort((a, b) => b.thisReleaseDate - a.thisReleaseDate);
+    // Converts the `platforms` object to a sorted array
+    release.platforms = sortByProperty(release.platforms, 'ordinal');
+    releases.push(release);
+  });
+
+  // Sort releases by name in descending order.
+  // The release timestamp can't be relied upon due to out-of-order releases.
+  // Example: 'jdk8u191-b12' was released after 'jdk8u192-b12'
+  sortByProperty(releases, 'release_name', true);
 
   const template = Handlebars.compile(document.getElementById('template').innerHTML);
-  document.getElementById('archive-table-body').innerHTML = template({htmlTemplate: RELEASEARRAY});
+  document.getElementById('archive-table-body').innerHTML = template({releases});
 
   setPagination();
-  setTickLink();
 
   loading.innerHTML = ''; // remove the loading dots
 

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -42,11 +42,25 @@ module.exports.getPlatformOrder = (searchableName) => {
   return platforms.findIndex((platform) => platform.searchableName == searchableName);
 }
 
-module.exports.orderPlatforms = (inputArray, attr = 'thisPlatformOrder') => {
-  return inputArray.sort((assetA, assetB) => {
-    return assetA[attr] < assetB[attr] ? -1 : assetA[attr] > assetB[attr] ? 1 : 0;
-  });
-}
+module.exports.orderPlatforms = (input, attr = 'thisPlatformOrder') => {
+  return sortByProperty(input, attr);
+};
+
+const sortByProperty = module.exports.sortByProperty = (input, property, descending) => {
+  const invert = descending ? -1 : 1;
+  const sorter = (a, b) => {
+    return invert * (a[property] > b[property] ? 1 : a[property] < b[property] ? -1 : 0);
+  };
+
+  if (Array.isArray(input)) {
+    return input.sort(sorter);
+  } else {
+    // Preserve the source object key as '_key'
+    return Object.keys(input)
+      .map(_key => Object.assign(input[_key], {_key}))
+      .sort(sorter);
+  }
+};
 
 // gets the BINARY EXTENSION when you pass in 'searchableName'
 module.exports.getBinaryExt = (searchableName) => lookup[searchableName].binaryExtension;

--- a/src/scss/styles-11-archive.scss
+++ b/src/scss/styles-11-archive.scss
@@ -23,16 +23,15 @@ $tableblue-even: #1F2F4E;
   border-collapse: separate;
   border-spacing: .2rem 2rem;
   white-space: nowrap;
-}
 
-.archive-container>tbody>tr>td {
-  padding: 1rem 2rem;
-  background-color: #fff;
-  margin: 3rem 0.1rem;
-  font-size: 0.8rem;
-}
+  td.release-info {
+    vertical-align: top;
+  }
 
-.archive-container {
+  td.download {
+    padding: 0.2rem;
+  }
+
   .grey-button, .blue-button  {
     font-size: inherit;
     width: 100%;
@@ -41,10 +40,12 @@ $tableblue-even: #1F2F4E;
   }
 }
 
-.archive-container .download-td {
-  padding: 0.2rem;
+.archive-container > tbody > tr > td {
+  padding: 1rem 2rem;
+  background-color: #fff;
+  margin: 3rem 0.1rem;
+  font-size: 0.8rem;
 }
-
 
 .archive-platforms {
   border-spacing: .5rem 0;
@@ -54,20 +55,4 @@ $tableblue-even: #1F2F4E;
   display: inline-block;
   margin: auto;
   margin: 2rem 1rem 0 1rem;
-}
-
-.archive-platforms span.tick {
-  float: right;
-  position: relative;
-  right: -0.7rem;
-  top: 0.3rem;
-  img {
-    height: 1.2rem;
-  }
-}
-
-.column-names span{
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-  display: inline-block;
 }


### PR DESCRIPTION
This PR adds support for displaying multiple release assets (e.g. Installer, JDK, and JRE) on the Archive page.

Resolves #381

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
