### PR TITLE
Update Windows install commands to use standard Powershell unzip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -831,9 +831,9 @@
       }
     },
     "ajv": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.5",
     "@babel/preset-env": "^7.1.5",
-    "ajv": "^6.5.5",
+    "ajv": "^6.7.0",
     "babelify": "^10.0.0",
     "base64-img": "^1.0.4",
     "browser-sync": "^2.26.3",

--- a/src/json/config.json
+++ b/src/json/config.json
@@ -110,7 +110,7 @@
       "logo": "windows.png",
       "binaryExtension": ".zip",
       "installerExtension": ".exe",
-      "installCommand": "unzip FILENAME",
+      "installCommand": "Expand-Archive -Path .\\FILENAME -DestinationPath .",
       "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
       "checksumCommand": "certutil -hashfile FILENAME SHA256",
       "osDetectionString": "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP"
@@ -126,7 +126,7 @@
       "logo": "windows.png",
       "binaryExtension": ".zip",
       "installerExtension": ".exe",
-      "installCommand": "unzip FILENAME",
+      "installCommand": "Expand-Archive -Path .\\FILENAME -DestinationPath .",
       "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
       "checksumCommand": "certutil -hashfile FILENAME SHA256",
       "osDetectionString": "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP"


### PR DESCRIPTION
Fix for #400. Replaces usages of non-standard `unzip` in Win32/64 installation string templates with an equivalent Powershell command: 
```powershell
Expand-Archive -Path .\FILENAME -DestinationPath .
```

##### Checklist

- [x] `npm test` passes
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
