### PR TITLE
Update support tables for OpenJDK with OpenJ9

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -209,7 +209,7 @@
             <tbody>
                 <tr>
                     <td>OSX 10.10+</td>
-                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
0.12.0 release of OpenJ9 includes support for
x86 macOS platforms. Support table updated
accordingly.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
