### PR TITLE
Support table missing for Solaris

### DIFF
--- a/src/handlebars/supported_platforms.handlebars
+++ b/src/handlebars/supported_platforms.handlebars
@@ -188,6 +188,26 @@
             </tbody>
         </table>
 
+        <table>
+            <thead>
+                <tr>
+                    <th>Solaris</th>
+                    <th>sparcv9</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Solaris 10</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>Solaris 11</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+            </tbody>
+        </table>
+		
+		
         <h3 id="openjdk11_platforms">OpenJDK 11</h3>
 
         <p>Where available, OpenJDK 11 binaries are supported on the minimum operating system levels shown in the following tables:</p>


### PR DESCRIPTION
For OpenJDK 8: Added Solaris table and included support
for Solaris 10 and 11 for HotSpot.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
