### PR TITLE
Add upstream builds to website (v2)

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -12,7 +12,7 @@
       <p>These binaries are built by Red Hat on behalf of the OpenJDK jdk8u and jdk11u projects. The binaries are created from the unmodified source code at OpenJDK. Support is not provided. If you are looking for the AdoptOpenJDK supported binaries then please find them <a href="./index.html">here</a>.</p>
     </div>
 
-    <h2>Ready for Use<h2>
+    <h2>Ready for Use</h2>
 
     <div class="download">
         <table id="release">
@@ -37,7 +37,7 @@
         </table>
     </div>
 
-    <h2>Early Access (EA)<h2>
+    <h2>Early Access (EA)</h2>
 
     <div class="download">
         <table id="ea">

--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -3,7 +3,7 @@
 <!-- TODO Style should match installation page, it doesn't quite... -->
 <main class="grey-bg upstream">
 
-  <h1 class="margin-bottom large-title">Upstream Builds</h1>
+  <h1 class="margin-bottom large-title">OpenJDK Project Builds</h1>
 
   <div class="info-page-container upstream blue-link-section">
 
@@ -12,128 +12,72 @@
       <p>These binaries are built by Red Hat on behalf of the OpenJDK jdk8u and jdk11u projects. The binaries are created from the unmodified source code at OpenJDK. Support is not provided. If you are looking for the AdoptOpenJDK supported binaries then please find them <a href="./index.html">here</a>.</p>
     </div>
 
-    <h2>OpenJDK8 Builds</h2>
+    <h2>Ready for Use<h2>
 
     <div class="download">
-      <h3 class="align-center">JDK 8u212-b02 EA build</h3>
-      <table>
-        <tr>
-          <td>OpenJDK8U-sources_8u212b02_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-sources_8u212b02_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-sources_8u212b02_ea.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK8U-x64_linux_8u212b02_ea-debuginfo</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea-debuginfo.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea-debuginfo.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK8U-x64_linux_8u212b02_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK8u-x64_windows_8u212b02_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8u-x64_windows_8u212b02_ea.zip">zip</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8u-x64_windows_8u212b02_ea.zip.sign">signature</a></td>
-        </tr>
-      </table>
+        <table id="release">
+            <tr>
+                <th>JDK</th>
+                <th>Linux</th>
+                <th>Windows</th>
+                <th>Source</th>
+            </tr>
+            <tr>
+                <td>OpenJDK 11</td>
+                <td>N/A</td>
+                <td>N/A</td>
+                <td>N/A</td>
+            </tr>
+            <tr>
+                <td>OpenJDK 8</td>
+                <td>N/A</td>
+                <td>N/A</td>
+                <td>N/A</td>
+            </tr>
+        </table>
     </div>
 
-    <div class="download">
-      <h3 class="align-center">JDK 8u212-b01 EA build</h3>
-      <table>
-        <tr>
-          <td>OpenJDK8U-sources_8u212b01_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-sources_8u212b01_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-sources_8u212b01_ea.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK8U-x64_linux_8u212b01_ea-debuginfo</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-x64_linux_8u212b01_ea-debuginfo.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-x64_linux_8u212b01_ea-debuginfo.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK8U-x64_linux_8u212b01_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-x64_linux_8u212b01_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-x64_linux_8u212b01_ea.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK8u-x64_windows_8u212b01_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8u-x64_windows_8u212b01_ea.zip">zip</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8u-x64_windows_8u212b01_ea.zip.sign">signature</a></td>
-        </tr>
-      </table>
-    </div>
-
-    <h2>OpenJDK11 Builds</h2>
+    <h2>Early Access (EA)<h2>
 
     <div class="download">
-      <h3 class="align-center">JDK 11.0.3+6 EA build</h3>
-      <table>
-        <tr>
-          <td>OpenJDK11U-sources_11.0.3_6_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-sources_11.0.3_6_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-sources_11.0.3_6_ea.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK11U-x64_linux_11.0.3_6_ea-debuginfo</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea-debuginfo.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea-debuginfo.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK11U-x64_linux_11.0.3_6_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK11U-x64_windows_11.0.3_6_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_windows_11.0.3_6_ea.zip">zip</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_windows_11.0.3_6_ea.zip.sign">signature</a></td>
-        </tr>
-      </table>
-    </div>
-
-    <div class="download">
-      <h3 class="align-center">JDK 11.0.3+5 EA build</h3>
-      <table>
-        <tr>
-          <td>OpenJDK11U-sources_11.0.3_5_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-sources_11.0.3_5_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-sources_11.0.3_5_ea.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK11U-x64_linux_11.0.3_5_ea-debuginfo</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-x64_linux_11.0.3_5_ea-debuginfo.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-x64_linux_11.0.3_5_ea-debuginfo.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK11U-x64_linux_11.0.3_5_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-x64_linux_11.0.3_5_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-x64_linux_11.0.3_5_ea.tar.gz.sign">signature</a></td>
-        </tr>
-      </table>
-    </div>
-
-    <div class="download">
-      <h3 class="align-center">JDK 11.0.3+4 EA build</h3>
-      <table>
-        <tr>
-          <td>OpenJDK11U-sources_11.0.3_4_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-sources_11.0.3_4_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-sources_11.0.3_4_ea.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK11U-x64_linux_11.0.3_4_ea-debuginfo</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-x64_linux_11.0.3_4_ea-debuginfo.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-x64_linux_11.0.3_4_ea-debuginfo.tar.gz.sign">signature</a></td>
-        </tr>
-        <tr>
-          <td>OpenJDK11U-x64_linux_11.0.3_4_ea</td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-x64_linux_11.0.3_4_ea.tar.gz">tar.gz</a></td>
-          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-x64_linux_11.0.3_4_ea.tar.gz.sign">signature</a></td>
-        </tr>
-      </table>
+        <table id="ea">
+            <tr>
+                <th>JDK</th>
+                <th>Linux</th>
+                <th>Windows</th>
+                <th>Source</th>
+            </tr>
+            <tr>
+                <td>OpenJDK 11 EA</td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea.tar.gz">Linux x86_64 11.0.3+6</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea.tar.gz.sign">signature</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_windows_11.0.3_6_ea.zip">Windows x86_64 11.0.3+6</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_windows_11.0.3_6_ea.zip.sign">signature</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-sources_11.0.3_6_ea.tar.gz">Source Tarball 11.0.3+6</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-sources_11.0.3_6_ea.tar.gz.sign">signature</a>)
+                </td>
+            </tr>
+            <tr>
+                <td>OpenJDK 8 EA</td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea.tar.gz">Linux x86_64 8u212-b02</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea.tar.gz.sign">signature</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8u-x64_windows_8u212b02_ea.zip">Windows x86_64 8u212-b02</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8u-x64_windows_8u212b02_ea.zip.sign">signature</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-sources_8u212b02_ea.tar.gz">Source Tarball 8u212-b02</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-sources_8u212b02_ea.tar.gz.sign">signature</a>)
+                </td>
+            </tr>
+        </table>
     </div>
 
   </div>

--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -7,6 +7,11 @@
 
   <div class="info-page-container upstream blue-link-section">
 
+    <div class="callout">
+      <h3 class="bold">What are these binaries?</h3>
+      <p>These binaries are built by Red Hat on behalf of the OpenJDK jdk8u and jdk11u projects. The binaries are created from the unmodified source code at OpenJDK. Support is not provided. If you are looking for the AdoptOpenJDK supported binaries then please find them <a href="./index.html">here</a>.</p>
+    </div>
+
     <h2>OpenJDK8 Builds</h2>
 
     <div class="download">

--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -1,0 +1,138 @@
+{{> header title='Upstream | ' }}
+
+<!-- TODO Style should match installation page, it doesn't quite... -->
+<main class="grey-bg upstream">
+
+  <h1 class="margin-bottom large-title">Upstream Builds</h1>
+
+  <div class="info-page-container upstream blue-link-section">
+
+    <h2>OpenJDK8 Builds</h2>
+
+    <div class="download">
+      <h3 class="align-center">JDK 8u212-b02 EA build</h3>
+      <table>
+        <tr>
+          <td>OpenJDK8U-sources_8u212b02_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-sources_8u212b02_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-sources_8u212b02_ea.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK8U-x64_linux_8u212b02_ea-debuginfo</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea-debuginfo.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea-debuginfo.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK8U-x64_linux_8u212b02_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK8u-x64_windows_8u212b02_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8u-x64_windows_8u212b02_ea.zip">zip</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8u-x64_windows_8u212b02_ea.zip.sign">signature</a></td>
+        </tr>
+      </table>
+    </div>
+
+    <div class="download">
+      <h3 class="align-center">JDK 8u212-b01 EA build</h3>
+      <table>
+        <tr>
+          <td>OpenJDK8U-sources_8u212b01_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-sources_8u212b01_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-sources_8u212b01_ea.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK8U-x64_linux_8u212b01_ea-debuginfo</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-x64_linux_8u212b01_ea-debuginfo.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-x64_linux_8u212b01_ea-debuginfo.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK8U-x64_linux_8u212b01_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-x64_linux_8u212b01_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8U-x64_linux_8u212b01_ea.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK8u-x64_windows_8u212b01_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8u-x64_windows_8u212b01_ea.zip">zip</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b01/OpenJDK8u-x64_windows_8u212b01_ea.zip.sign">signature</a></td>
+        </tr>
+      </table>
+    </div>
+
+    <h2>OpenJDK11 Builds</h2>
+
+    <div class="download">
+      <h3 class="align-center">JDK 11.0.3+6 EA build</h3>
+      <table>
+        <tr>
+          <td>OpenJDK11U-sources_11.0.3_6_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-sources_11.0.3_6_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-sources_11.0.3_6_ea.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK11U-x64_linux_11.0.3_6_ea-debuginfo</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea-debuginfo.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea-debuginfo.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK11U-x64_linux_11.0.3_6_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK11U-x64_windows_11.0.3_6_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_windows_11.0.3_6_ea.zip">zip</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_windows_11.0.3_6_ea.zip.sign">signature</a></td>
+        </tr>
+      </table>
+    </div>
+
+    <div class="download">
+      <h3 class="align-center">JDK 11.0.3+5 EA build</h3>
+      <table>
+        <tr>
+          <td>OpenJDK11U-sources_11.0.3_5_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-sources_11.0.3_5_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-sources_11.0.3_5_ea.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK11U-x64_linux_11.0.3_5_ea-debuginfo</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-x64_linux_11.0.3_5_ea-debuginfo.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-x64_linux_11.0.3_5_ea-debuginfo.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK11U-x64_linux_11.0.3_5_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-x64_linux_11.0.3_5_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B5/OpenJDK11U-x64_linux_11.0.3_5_ea.tar.gz.sign">signature</a></td>
+        </tr>
+      </table>
+    </div>
+
+    <div class="download">
+      <h3 class="align-center">JDK 11.0.3+4 EA build</h3>
+      <table>
+        <tr>
+          <td>OpenJDK11U-sources_11.0.3_4_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-sources_11.0.3_4_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-sources_11.0.3_4_ea.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK11U-x64_linux_11.0.3_4_ea-debuginfo</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-x64_linux_11.0.3_4_ea-debuginfo.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-x64_linux_11.0.3_4_ea-debuginfo.tar.gz.sign">signature</a></td>
+        </tr>
+        <tr>
+          <td>OpenJDK11U-x64_linux_11.0.3_4_ea</td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-x64_linux_11.0.3_4_ea.tar.gz">tar.gz</a></td>
+          <td><a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B4/OpenJDK11U-x64_linux_11.0.3_4_ea.tar.gz.sign">signature</a></td>
+        </tr>
+      </table>
+    </div>
+
+  </div>
+
+</main>
+
+{{> footer }}

--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -12,7 +12,7 @@
       <p>These binaries are built by Red Hat on behalf of the OpenJDK jdk8u and jdk11u projects. The binaries are created from the unmodified source code at OpenJDK. Support is not provided. If you are looking for the AdoptOpenJDK supported binaries then please find them <a href="./index.html">here</a>.</p>
     </div>
 
-    <h2>Ready for Use</h2>
+    <h2>Official Release</h2>
 
     <div class="download">
         <table id="release">

--- a/src/scss/styles-12-upstream.scss
+++ b/src/scss/styles-12-upstream.scss
@@ -1,0 +1,17 @@
+$mainblue: #152935;
+$maingrey: #F5F5F5;
+$brighterblue: #3D70B2;
+$accentgrey: #dadada;
+
+
+// upstream CSS
+
+table {
+  margin: 0px auto;
+}
+
+.download {
+  background-color: $accentgrey;
+  padding: 0.5em;
+  margin: 1em;
+}

--- a/src/scss/styles-12-upstream.scss
+++ b/src/scss/styles-12-upstream.scss
@@ -1,10 +1,4 @@
-$mainblue: #152935;
-$maingrey: #F5F5F5;
-$brighterblue: #3D70B2;
 $accentgrey: #dadada;
-
-
-// upstream CSS
 
 table {
   margin: 0px auto;

--- a/src/scss/styles-12-upstream.scss
+++ b/src/scss/styles-12-upstream.scss
@@ -9,3 +9,15 @@ table {
   padding: 0.5em;
   margin: 1em;
 }
+
+table#release, table#ea {
+  margin-left: 0;
+  margin-right: 0;
+  font-size: small;
+  border-collapse: collapse;
+  text-align: center;
+}
+
+table#release td, table#ea td {
+  padding: 5px 0px 10px 2px;
+}

--- a/src/scss/styles-12-upstream.scss
+++ b/src/scss/styles-12-upstream.scss
@@ -1,23 +1,9 @@
 $accentgrey: #dadada;
 
 table {
-  margin: 0px auto;
-}
-
-.download {
   background-color: $accentgrey;
-  padding: 0.5em;
-  margin: 1em;
-}
-
-table#release, table#ea {
-  margin-left: 0;
-  margin-right: 0;
-  font-size: small;
-  border-collapse: collapse;
-  text-align: center;
 }
 
 table#release td, table#ea td {
-  padding: 5px 0px 10px 2px;
+  padding: 0.5em;
 }


### PR DESCRIPTION
Follow up for:
https://github.com/AdoptOpenJDK/openjdk-website/pull/446/

Specifically commit: 56c393c
