### PR TITLE
Add April CPU, 2019, upstream OpenJDK project builds

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -23,16 +23,34 @@
                 <th>Source</th>
             </tr>
             <tr>
-                <td>OpenJDK 11</td>
-                <td>N/A</td>
-                <td>N/A</td>
-                <td>N/A</td>
+                <td class="first_col">OpenJDK 11</td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_linux_11.0.3_7.tar.gz">Linux x86_64 11.0.3+7</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_linux_11.0.3_7.tar.gz.sign">signature</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_windows_11.0.3_7.zip">Windows x86_64 11.0.3+7</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_windows_11.0.3_7.zip.sign">signature</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-sources_11.0.3_7.tar.gz">Source Tarball 11.0.3+7</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-sources_11.0.3_7.tar.gz.sign">signature</a>)
+                </td>
             </tr>
             <tr>
-                <td>OpenJDK 8</td>
-                <td>N/A</td>
-                <td>N/A</td>
-                <td>N/A</td>
+                <td class="first_col">OpenJDK 8</td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b03/OpenJDK8U-x64_linux_8u212b03.tar.gz">Linux x86_64 8u212-b03</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b03/OpenJDK8U-x64_linux_8u212b03.tar.gz.sign">signature</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b03/OpenJDK8u-x64_windows_8u212b03.zip">Windows x86_64 8u212-b03</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b03/OpenJDK8u-x64_windows_8u212b03.zip.sign">signature</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b03/OpenJDK8U-sources_8u212b03.tar.gz">Source Tarball 8u212-b03</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b03/OpenJDK8U-sources_8u212b03.tar.gz.sign">signature</a>)
+                </td>
             </tr>
         </table>
     </div>
@@ -48,7 +66,7 @@
                 <th>Source</th>
             </tr>
             <tr>
-                <td>OpenJDK 11 EA</td>
+                <td class="first_col">OpenJDK 11 EA</td>
                 <td>
                     <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea.tar.gz">Linux x86_64 11.0.3+6</a>,
                     (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B6/OpenJDK11U-x64_linux_11.0.3_6_ea.tar.gz.sign">signature</a>)
@@ -63,7 +81,7 @@
                 </td>
             </tr>
             <tr>
-                <td>OpenJDK 8 EA</td>
+                <td class="first_col">OpenJDK 8 EA</td>
                 <td>
                     <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea.tar.gz">Linux x86_64 8u212-b02</a>,
                     (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b02/OpenJDK8U-x64_linux_8u212b02_ea.tar.gz.sign">signature</a>)

--- a/src/scss/styles-13-upstream.scss
+++ b/src/scss/styles-13-upstream.scss
@@ -7,3 +7,7 @@ $accentgrey: #dadada;
 table#release td, table#ea td {
   padding: 0.5em;
 }
+
+table#release td.first_col, table#ea td.first_col {
+  width: 125px;
+}


### PR DESCRIPTION
I've uploaded upstream project builds to openjdk11-upstream-releases and openjdk8-upstream-releases. This PR updates the links on `upstream.html` for the `Official Release` table.

The width styling helps so that `OpenJDK 11` and `OpenJDK 8` (and EA equivalents) don't wrap around in the first column of the tables.

Thanks for you help getting this merged!