### PR TITLE
Change tick to cross for OpenJFX (coming soon)

### DIFF
--- a/src/handlebars/migration.handlebars
+++ b/src/handlebars/migration.handlebars
@@ -49,7 +49,7 @@
             <td>JavaFX</td>
             <td><a href="#openjfx">OpenJFX</a></td>
             <td><i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">no</span></td>
-            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span> (coming soon)</td>
+            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">no</span> (coming soon)</td>
           </tr>
           <tr>
             <td>T2K font rendering engine</td>


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Currently the page on features has a tick next to OpenJFX11 with the words "Coming Soon". This should be a cross with the words "Coming Soon" to be consistent with how the other such items are displayed.

If anyone knows of a reason why it was a tick to begin 