### PR TITLE
Add link to Aarch64 Linux build in upstream.html

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -25,8 +25,14 @@
             <tr>
                 <td class="first_col">OpenJDK 11</td>
                 <td>
+                    <div>
                     <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_linux_11.0.3_7.tar.gz">Linux x86_64 11.0.3+7</a>,
                     (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_linux_11.0.3_7.tar.gz.sign">signature</a>)
+                    </div>
+                    <div>
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-aarch64_linux_11.0.3_7.tar.gz">Linux aarch64 11.0.3+7</a>,
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-aarch64_linux_11.0.3_7.tar.gz.sign">signature</a>)
+                    </div>
                 </td>
                 <td>
                     <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-x64_windows_11.0.3_7.zip">Windows x86_64 11.0.3+7</a>,


### PR DESCRIPTION
JDK 11 only, as the Aarch64 port only got included in JDK 9+