### PR TITLE
Update migration for IcedTea-Web on OpenJDK 11

### DIFF
--- a/src/handlebars/migration.handlebars
+++ b/src/handlebars/migration.handlebars
@@ -43,7 +43,7 @@
             <td>Java Web Start/browser plugin</td>
             <td><a href="#icedtea-web">IcedTea-Web</a></td>
             <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span></td>
-            <td><i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">no</span> (coming soon)</td>
+            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span></td>
           </tr>
           <tr>
             <td>JavaFX</td>
@@ -119,8 +119,8 @@
       application</a>. Whilst IcedTea-Web is written to operate in the same way as Java Web Start there are a few known differences, which are raised as issues in the
       <a href="https://github.com/AdoptOpenJDK/icedtea-web" target="_blank">GitHub project</a>. Work is ongoing to minimize or eliminate these differences.
       </p>
-      <p><i class="fa fa-pencil" aria-hidden="true"></i><span class="sr-only">Note:</span> Currently, IcedTea-Web is bundled only with the Windows MSI installer for OpenJDK 8.
-      Further work is underway to provide IcedTea-Web as an optional component of AdoptOpenJDK installers for other versions and platforms.
+      <p><i class="fa fa-pencil" aria-hidden="true"></i><span class="sr-only">Note:</span> Currently, IcedTea-Web is bundled only with the Windows MSI installer for OpenJDK 8 and 11.
+      Further work is underway to provide IcedTea-Web as an optional component of AdoptOpenJDK installers for other platforms.
       </p>
 
       <h3 id="openjfx">OpenJFX</h3>


### PR DESCRIPTION
MSI installer for OpenJDK 11 also has optional
IcedTea-Web component. Update table and
migration section for IcedTea-web.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
