### PR TITLE
IcedTea web installer packages are x64 only

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -110,6 +110,8 @@
         from the command line. The installer is designed for use on a per-machine basis, not per-user basis, so you can have only one installation of the MSI
         on a machine for all users.</p>
 
+        <p>Note: Windows installer packages are supported only on Windows x64 systems.</p>
+
      <h4 id="windows-msi-gui">GUI installation</h4>
 
         <p>Instructions for running an interactive installation using the Windows MSI installer.</p>

--- a/src/handlebars/migration.handlebars
+++ b/src/handlebars/migration.handlebars
@@ -108,7 +108,10 @@
 
       <h3 id="icedtea-web">IcedTea-Web</h3>
 
-      <p>IcedTea-Web is available as an optional component of the AdoptOpenJDK installer for Windows that you can select from the <strong>Custom Setup</strong> panel.
+      <p>IcedTea-Web is available to download from the <a href="./icedtea-web.html" target="_blank">Iced-Tea Web project page</a> in Linux, Windows,
+      and Portable package formats.</p>
+
+      <p>IcedTea-Web is also available as an optional component of the AdoptOpenJDK installer for Windows that you can select from the <strong>Custom Setup</strong> panel.
       You can also choose to associate JNLP files so that when a user clicks on the JNLP file, it is automatically opened with IcedTea-Web.
       </p>
       <p>By default, IcedTea-Web is installed into the OpenJDK directory and has the same executable name (<tt>javaws.exe</tt>) as Java Web Start. To configure settings,
@@ -120,7 +123,7 @@
       <a href="https://github.com/AdoptOpenJDK/icedtea-web" target="_blank">GitHub project</a>. Work is ongoing to minimize or eliminate these differences.
       </p>
       <p><i class="fa fa-pencil" aria-hidden="true"></i><span class="sr-only">Note:</span> Currently, IcedTea-Web is bundled only with the Windows MSI installer for OpenJDK 8 and 11.
-      Further work is underway to provide IcedTea-Web as an optional component of AdoptOpenJDK installers for other platforms.
+      The installers are available only for x64 Windows systems. Further work is underway to provide IcedTea-Web as an optional component of AdoptOpenJDK installers for other platforms.
       </p>
 
       <h3 id="openjfx">OpenJFX</h3>


### PR DESCRIPTION
Add information to the installation page and
migration page to indicate that MSI installers are
supported only on x64 systems.

Also added a sentence to point to the new IcedTea-Web
downloads page from the migration guide.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
