### PR TITLE
IcedTea-Web added only to v8 MSI installer

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -129,8 +129,8 @@
                 <br>
                 <ul>
                   <li>Updating the <strong>JAVA_HOME</strong> environment variable</li>
-                  <li>Installing IcedTea-Web</li>
-                  <li>Associate <tt>.jnlp</tt> files with the IcedTea-Web application</li>
+                  <li>Installing IcedTea-Web (AdoptOpenJDK 8 only)</li>
+                  <li>Associate <tt>.jnlp</tt> files with the IcedTea-Web application (AdoptOpenJDK 8 only)</li>
                 </ul>
         <p>4. When you have chosen the features that you want to install, click <strong>Next</strong>.</p>
         <p>5. Click <strong>Install</strong> to begin the installation.</p>
@@ -173,12 +173,12 @@
                 </tr>
 
                 <tr>
-                  <td><tt>FeatureIcedTeaWeb</tt></td>
+                  <td><tt>FeatureIcedTeaWeb</tt> (AdoptOpenJDK 8 only)</td>
                   <td>Install <a href="https://www.github.com/adoptopenjdk/icedtea-web" target="_blank">IcedTea-Web</a></td>
                 </tr>
 
                 <tr>
-                  <td><tt>FeatureJNLPFileRunWith</tt></td>
+                  <td><tt>FeatureJNLPFileRunWith</tt> (AdoptOpenJDK 8 only)</td>
                   <td>Associate <tt>.jnlp</tt> files with IcedTea-web</td>
                 </tr>
 

--- a/src/handlebars/migration.handlebars
+++ b/src/handlebars/migration.handlebars
@@ -40,10 +40,10 @@
         </thead>
         <tbody>
           <tr>
-            <td>Java Web Start/browser plugin</td>
+            <td>Java Web Start</td>
             <td><a href="#icedtea-web">IcedTea-Web</a></td>
             <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span></td>
-            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">yes</span></td>
+            <td><i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">no</span></td>
           </tr>
           <tr>
             <td>JavaFX</td>
@@ -108,10 +108,13 @@
 
       <h3 id="icedtea-web">IcedTea-Web</h3>
 
+      <p>Java Web Start was deprecated by Oracle in Java SE 8 and removed in Java SE 9. IcedTea-Web can provide equivalent functionality
+        for AdoptOpenJDK 8 users.</p>
+
       <p>IcedTea-Web is available to download from the <a href="./icedtea-web.html" target="_blank">Iced-Tea Web project page</a> in Linux, Windows,
       and Portable package formats.</p>
 
-      <p>IcedTea-Web is also available as an optional component of the AdoptOpenJDK installer for Windows that you can select from the <strong>Custom Setup</strong> panel.
+      <p>IcedTea-Web is also available as an optional component of the AdoptOpenJDK installer for 64-bit Windows on OpenJDK 8 that you can select from the <strong>Custom Setup</strong> panel.
       You can also choose to associate JNLP files so that when a user clicks on the JNLP file, it is automatically opened with IcedTea-Web.
       </p>
       <p>By default, IcedTea-Web is installed into the OpenJDK directory and has the same executable name (<tt>javaws.exe</tt>) as Java Web Start. To configure settings,
@@ -122,8 +125,8 @@
       application</a>. Whilst IcedTea-Web is written to operate in the same way as Java Web Start there are a few known differences, which are raised as issues in the
       <a href="https://github.com/AdoptOpenJDK/icedtea-web" target="_blank">GitHub project</a>. Work is ongoing to minimize or eliminate these differences.
       </p>
-      <p><i class="fa fa-pencil" aria-hidden="true"></i><span class="sr-only">Note:</span> Currently, IcedTea-Web is bundled only with the Windows MSI installer for OpenJDK 8 and 11.
-      The installers are available only for x64 Windows systems. Further work is underway to provide IcedTea-Web as an optional component of AdoptOpenJDK installers for other platforms.
+      <p><i class="fa fa-pencil" aria-hidden="true"></i><span class="sr-only">Note:</span> Currently, IcedTea-Web is bundled only with the Windows MSI installer for AdoptOpenJDK 8.
+      The installers are available only for x64 Windows systems. Further work is underway to provide IcedTea-Web as an optional component of AdoptOpenJDK 8 installers for other platforms.
       </p>
 
       <h3 id="openjfx">OpenJFX</h3>


### PR DESCRIPTION
Fix the migration guide and the installation page
for AdoptOpenJDK 8 only.

Reference: https://github.com/AdoptOpenJDK/openjdk-installer/issues/120

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
