### PR TITLE
Add new JDK 11 and JDK 8 EA builds to upstream.html

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -121,13 +121,13 @@
             <tr>
                 <td rowspan="3" class="first_col">OpenJDK 11 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">11.0.4-ea+2</td>
+                <td colspan="2" class="bold midl">11.0.4-ea+4</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">11.0.4-ea+2</td>
+                <td colspan="2" class="bold midl">11.0.4-ea+4</td>
                 <td rowspan="3">
                     <!-- Source Tarball JDK 11 -->
-                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B2/OpenJDK11U-sources_11.0.4_2_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B2/OpenJDK11U-sources_11.0.4_2_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-sources_11.0.4_4_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-sources_11.0.4_4_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -135,16 +135,24 @@
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B2/OpenJDK11U-x64_linux_11.0.4_2_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B2/OpenJDK11U-x64_linux_11.0.4_2_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jdk_x64_linux_11.0.4_4_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jdk_x64_linux_11.0.4_4_ea.tar.gz.sign">signature</a>)
+                    </div>
+                    <div>
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jre_x64_linux_11.0.4_4_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jre_x64_linux_11.0.4_4_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td rowspan="2" class="arch no_right">x86_64</td>
                 <td rowspan="2" class="no_left">
                     <!-- Windows x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B2/OpenJDK11U-x64_windows_11.0.4_2_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B2/OpenJDK11U-x64_windows_11.0.4_2_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jdk_x64_windows_11.0.4_4_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jdk_x64_windows_11.0.4_4_ea.zip.sign">signature</a>)
+                    </div>
+                    <div>
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jre_x64_windows_11.0.4_4_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jre_x64_windows_11.0.4_4_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -153,8 +161,12 @@
                 <td class="no_left">
                     <!-- Linux aarch64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B2/OpenJDK11U-aarch64_linux_11.0.4_2_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B2/OpenJDK11U-aarch64_linux_11.0.4_2_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jdk_aarch64_linux_11.0.4_4_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jdk_aarch64_linux_11.0.4_4_ea.tar.gz.sign">signature</a>)
+                    </div>
+                    <div>
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jre_aarch64_linux_11.0.4_4_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B4/OpenJDK11U-jre_aarch64_linux_11.0.4_4_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -167,12 +179,12 @@
             <tr>
                 <td rowspan="2" class="first_col">OpenJDK 8 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">8u222-ea-b02</td>
+                <td colspan="2" class="bold midl">8u222-ea-b03</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">8u222-ea-b02</td>
+                <td colspan="2" class="bold midl">8u222-ea-b03</td>
                 <td rowspan="2" class="midl">
-                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8U-sources_8u222b02_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8U-sources_8u222b02_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8U-sources_8u222b03_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8U-sources_8u222b03_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -180,24 +192,24 @@
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8U-x64_linux_8u222b02_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8U-x64_linux_8u222b02_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8U-jdk_x64_linux_8u222b03_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8U-jdk_x64_linux_8u222b03_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8U-jre_x64_linux_8u222b02_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8U-jre_x64_linux_8u222b02_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8U-jre_x64_linux_8u222b03_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8U-jre_x64_linux_8u222b03_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td class="arch no_right">x86_64</td>
                 <td class="no_left">
                     <!-- Windows x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8u-x64_windows_8u222b02_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8u-x64_windows_8u222b02_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8u-jdk_x64_windows_8u222b03_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8u-jdk_x64_windows_8u222b03_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8u-jre_x64_windows_8u222b02_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b02/OpenJDK8u-jre_x64_windows_8u222b02_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8u-jre_x64_windows_8u222b03_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b03/OpenJDK8u-jre_x64_windows_8u222b03_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
Also add links to JDK 11 JRE builds produced via the legacy-images
target.