### PR TITLE
Correct jdk12 release and version

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -112,8 +112,8 @@
           <td>Java 12</td>
           <td>March 2019</td>
           <td>
-              12.0.1<br />
-              Jun 2019
+              <strong>12.0.2<br/>
+              16th July 2019</strong>
           </td>
           <td>Sept 2019</td>
         </tr>


### PR DESCRIPTION
Current entry appears to be a typo. There is no plan to release any
jdk12 builds in June.

The next release should be version 12.0.2, and should coincide with
the other quarterly releases (for jdk8 and jdk11) in July.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
