### PR TITLE
Add WinXL variant to config

### DIFF
--- a/src/json/config.json
+++ b/src/json/config.json
@@ -156,6 +156,24 @@
       "osDetectionString": "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP"
     },
     {
+      "officialName": "Windows x64 Large Heap",
+      "searchableName": "X64_WINXL",
+      "attributes": {
+        "heap_size": "large",
+        "os": "windows",
+        "architecture": "x64"
+      },
+      "logo": "windows.png",
+      "binaryExtension": ".zip",
+      "installerExtension": ".msi",
+      "installCommand": "Expand-Archive -Path .\\FILENAME -DestinationPath .",
+      "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
+      "checksumCommand": "certutil -hashfile FILENAME SHA256",
+      "checksumAutoCommandHint": " (the command must be run using Command Prompt in the same directory you download the binary file and requires PowerShell 3.0+)",
+      "checksumAutoCommand": "powershell -command \"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;  iwr -outf FILEHASHNAME FILEHASHURL\" && powershell \"$CHECKSUMVAR=($(Get-FileHash -Algorithm SHA256 -LiteralPath FILENAME | Format-List -Property Hash | Out-String) -replace \\\"Hash : \\\", \\\"\\\" -replace \\\"`r`n\\\", \\\"\\\"); Select-String -LiteralPath FILEHASHNAME -Pattern $CHECKSUMVAR | Format-List -Property FileName | Out-String\" | find /i \"FILEHASHNAME\">Nul && ( echo \"FILENAME: The SHA-256 fingerprint matches\" ) || ( echo \"FILENAME: The SHA-256 fingerprint does NOT match\" )",
+      "osDetectionString": "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP"
+    },
+    {
       "officialName": "macOS x64",
       "searchableName": "X64_MAC",
       "attributes": {


### PR DESCRIPTION
- Copied from Win x64 variant
- Add 'Large Heap' to officialName
- Change heap size to 'large'

Related AdoptOpenJDK/openjdk-build#1099

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
