### PR TITLE
Update wording for "support" of OpenJDK Project Builds

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -9,7 +9,8 @@
 
     <div class="callout">
       <h3 class="bold">What are these binaries?</h3>
-      <p>These binaries are built by Red Hat on behalf of the OpenJDK jdk8u and jdk11u projects. The binaries are created from the unmodified source code at OpenJDK. Support is not provided. If you are looking for the AdoptOpenJDK supported binaries then please find them <a href="./index.html">here</a>.</p>
+      <p>These binaries are built by Red Hat on behalf of the OpenJDK jdk8u and jdk11u projects. The binaries are created from the unmodified source code at OpenJDK. Although no formal support agreement is
+provided, please report any bugs you may find to <a href="https://bugs.java.com/">https://bugs.java.com/</a>. If you are looking for the AdoptOpenJDK supported binaries then please find them <a href="./index.html">here</a>.</p>
     </div>
 
     <h2>Official Release</h2>


### PR DESCRIPTION
Let's use something less off-putting. The upstream project
will try to fix any bugs found even though there are no actual
SLAs.