### PR TITLE
Fix incorrect file names showing up in copied installation commands

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -56,15 +56,15 @@
                   </li>
                   <li>
                     Extract the <code><var extension>\{{thisBinaryExtension}}</var></code>. You can use the following command:
-                    <pre><code class="highlighted"><var id="unzip-\{{thisPlatform}}" unzipCommand>\{{thisUnzipCommand}}</var></code><span onclick="copyClipboard('#unzip-\{{thisPlatform}}')" class="copy-code-button">Copy</span></pre>
+                    <pre><code class="highlighted"><var id="unzip-\{{thisPlatform}}" unzipCommand>\{{thisUnzipCommand}}</var></code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
                   </li>
                   <li>
                     Add this version of Java to your PATH:
-                    <pre><code class="highlighted"><var id="path-\{{thisPlatform}}" pathCommand>\{{thisPathCommand}}</var></code><span onclick="copyClipboard('#path-\{{thisPlatform}}')" class="copy-code-button">Copy</span></pre>
+                    <pre><code class="highlighted"><var id="path-\{{thisPlatform}}" pathCommand>\{{thisPathCommand}}</var></code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
                   </li>
                   <li>
                     Check that Java has installed correctly:
-                    <pre><code id="java-\{{thisPlatform}}" class="highlighted">java -version</code><span onclick="copyClipboard('#java-\{{thisPlatform}}')" class="copy-code-button">Copy</span></pre>
+                    <pre><code id="java-\{{thisPlatform}}" class="highlighted">java -version</code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
                   </li>
                 </ol>
               </div>
@@ -73,9 +73,9 @@
               <h2 class="bold">Checking the SHA-256 checksum</h2>
               <p>Optionally, you can compare the SHA-256 checksum of your downloaded binary against the checksums that are provided for every release and nightly build.</p>
               <p>Use this command to generate a SHA-256 checksum of your downloaded binary, then open the corresponding <a href="\{{thisChecksumLink}}">checksum file</a> and ensure that it contains the same number.</p>
-              <pre><code class="highlighted"><var id="checksum-\{{thisPlatform}}" checksumCommand>\{{thisChecksumCommand}}</var></code><span onclick="copyClipboard('#checksum-\{{thisPlatform}}')" class="copy-code-button">Copy</span></pre>
+              <pre><code class="highlighted"><var id="checksum-\{{thisPlatform}}" checksumCommand>\{{thisChecksumCommand}}</var></code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
               <p>Alternative, you can download SHA-256 checksum file and verify downloaded binary using this command\{{thisChecksumAutoCommandHint}}:</p>
-              <pre><code class="highlighted"><var id="checksum-auto-command-\{{thisPlatformType}}" checksumAutoCommand>\{{thisChecksumAutoCommand}}</var></code><span onclick="copyClipboard('#checksum-auto-command-\{{thisPlatformType}}')" class="copy-code-button">Copy</span></pre>
+              <pre><code class="highlighted"><var id="checksum-auto-command-\{{thisPlatformType}}" checksumAutoCommand>\{{thisChecksumAutoCommand}}</var></code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
               <p>and confirm the command output succeeds.</p>
             </div>
 

--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -39,7 +39,12 @@
     <div id="loading"><img src="dist/assets/loading_dots.gif" width="40" height="40" alt="Content is loading."></div>
     <div id="error-container"></div>
 
-
+    {{#*inline "cmdblock"}}
+      <pre class="copy-code-block">
+        <code class="highlighted cmd-block"><var>{{{command}}}</var></code>
+        <span class="copy-code-button">Copy</span>
+      </pre>
+    {{/inline}}
     <div id="installation-container" class="info-page-container hide">
       <div id="installation-template">
         <script id="template" type="text/x-handlebars-template">
@@ -56,15 +61,15 @@
                   </li>
                   <li>
                     Extract the <code><var extension>\{{thisBinaryExtension}}</var></code>. You can use the following command:
-                    <pre><code class="highlighted"><var id="unzip-\{{thisPlatform}}" unzipCommand>\{{thisUnzipCommand}}</var></code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
+                    {{>cmdblock command="{{this.thisUnzipCommand}}" }}
                   </li>
                   <li>
                     Add this version of Java to your PATH:
-                    <pre><code class="highlighted"><var id="path-\{{thisPlatform}}" pathCommand>\{{thisPathCommand}}</var></code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
+                    {{>cmdblock command="{{this.thisPathCommand}}" }}
                   </li>
                   <li>
                     Check that Java has installed correctly:
-                    <pre><code id="java-\{{thisPlatform}}" class="highlighted">java -version</code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
+                    {{>cmdblock command="java -version" }}
                   </li>
                 </ol>
               </div>
@@ -73,9 +78,9 @@
               <h2 class="bold">Checking the SHA-256 checksum</h2>
               <p>Optionally, you can compare the SHA-256 checksum of your downloaded binary against the checksums that are provided for every release and nightly build.</p>
               <p>Use this command to generate a SHA-256 checksum of your downloaded binary, then open the corresponding <a href="\{{thisChecksumLink}}">checksum file</a> and ensure that it contains the same number.</p>
-              <pre><code class="highlighted"><var id="checksum-\{{thisPlatform}}" checksumCommand>\{{thisChecksumCommand}}</var></code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
+              {{>cmdblock command="{{this.thisChecksumCommand}}" }}
               <p>Alternative, you can download SHA-256 checksum file and verify downloaded binary using this command\{{thisChecksumAutoCommandHint}}:</p>
-              <pre><code class="highlighted"><var id="checksum-auto-command-\{{thisPlatformType}}" checksumAutoCommand>\{{thisChecksumAutoCommand}}</var></code><span onclick="copyPreviousSibling(this);" class="copy-code-button">Copy</span></pre>
+              {{>cmdblock command="{{this.thisChecksumAutoCommand}}" }}
               <p>and confirm the command output succeeds.</p>
             </div>
 

--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -7,9 +7,10 @@ const loading = document.getElementById('loading');
 const errorContainer = document.getElementById('error-container');
 const platformSelector = document.getElementById('platform-selector');
 
-global.copyClipboard = (elementSelector) => {
+global.copyPreviousSibling = (target) => {
+  const cmd = target.previousSibling.textContent;
   const input = document.createElement('input');
-  input.value = document.querySelector(elementSelector).textContent;
+  input.value = cmd;
 
   document.body.appendChild(input);
   input.select();
@@ -18,7 +19,7 @@ global.copyClipboard = (elementSelector) => {
   alert('Copied to clipboard');
 
   document.body.removeChild(input);
-}
+};
 
 module.exports.load = () => {
   setRadioSelectors();

--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -7,20 +7,6 @@ const loading = document.getElementById('loading');
 const errorContainer = document.getElementById('error-container');
 const platformSelector = document.getElementById('platform-selector');
 
-global.copyPreviousSibling = (target) => {
-  const cmd = target.previousSibling.textContent;
-  const input = document.createElement('input');
-  input.value = cmd;
-
-  document.body.appendChild(input);
-  input.select();
-
-  document.execCommand('copy');
-  alert('Copied to clipboard');
-
-  document.body.removeChild(input);
-};
-
 module.exports.load = () => {
   setRadioSelectors();
 
@@ -28,7 +14,7 @@ module.exports.load = () => {
     errorContainer.innerHTML = '<p>Error... no installation information has been found!</p>';
     loading.innerHTML = ''; // remove the loading dots
   });
-}
+};
 
 function buildInstallationHTML(releasesJson) {
   // create an array of the details for each asset that is attached to a release
@@ -99,6 +85,7 @@ function buildInstallationHTML(releasesJson) {
   hljs.initHighlightingOnLoad();
 
   setInstallationPlatformSelector(ASSETARRAY);
+  attachCopyButtonListeners();
   window.onhashchange = displayInstallPlatform;
 
   loading.innerHTML = ''; // remove the loading dots
@@ -107,6 +94,13 @@ function buildInstallationHTML(releasesJson) {
   installationContainer.className = installationContainer.className.replace(/(?:^|\s)hide(?!\S)/g, ' animated fadeIn ');
 }
 
+function attachCopyButtonListeners() {
+  document.querySelectorAll('.copy-code-block').forEach(codeBlock => {
+    const target = codeBlock.querySelector('code.cmd-block');
+    codeBlock.querySelector('.copy-code-button')
+      .addEventListener('click', () => copyElementTextContent(target));
+  });
+}
 
 function displayInstallPlatform() {
   const platformHash = window.location.hash.substr(1).toUpperCase();
@@ -163,4 +157,18 @@ function setInstallationPlatformSelector(thisReleasePlatforms) {
     window.location.hash = platformSelector.value.toLowerCase();
     displayInstallPlatform();
   };
+}
+
+function copyElementTextContent(target) {
+  const text = target.textContent;
+  const input = document.createElement('input');
+  input.value = text;
+
+  document.body.appendChild(input);
+  input.select();
+
+  document.execCommand('copy');
+  alert('Copied to clipboard');
+
+  document.body.removeChild(input);
 }


### PR DESCRIPTION
Fixes #519, tested in IE11 and Firefox 67.

The existing method grabs text from the DOM using an injected ID param based on platform (e.g. `#java-X64_WIN`) and does not account for JDK vs JRE selection.

This change uses the more-generic `previousSibling` selector to grab the text content of its nearest preceding sibling.

##### Checklist
- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
