### PR TITLE
Update to JDK 11.0.4+10 and JDK 8u222-b08 EA builds

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -122,13 +122,13 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="3" class="first_col">OpenJDK 11 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">11.0.4-ea+9</td>
+                <td colspan="2" class="bold midl">11.0.4-ea+10</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">11.0.4-ea+9</td>
+                <td colspan="2" class="bold midl">11.0.4-ea+10</td>
                 <td rowspan="3">
                     <!-- Source Tarball JDK 11 -->
-                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-sources_11.0.4_9_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-sources_11.0.4_9_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-sources_11.0.4_10_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-sources_11.0.4_10_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -136,24 +136,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jdk_x64_linux_11.0.4_9_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jdk_x64_linux_11.0.4_9_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_x64_linux_11.0.4_10_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_x64_linux_11.0.4_10_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jre_x64_linux_11.0.4_9_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jre_x64_linux_11.0.4_9_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_x64_linux_11.0.4_10_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_x64_linux_11.0.4_10_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td rowspan="2" class="arch no_right">x86_64</td>
                 <td rowspan="2" class="no_left">
                     <!-- Windows x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jdk_x64_windows_11.0.4_9_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jdk_x64_windows_11.0.4_9_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_x64_windows_11.0.4_10_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_x64_windows_11.0.4_10_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jre_x64_windows_11.0.4_9_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jre_x64_windows_11.0.4_9_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_x64_windows_11.0.4_10_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_x64_windows_11.0.4_10_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -162,12 +162,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux aarch64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jdk_aarch64_linux_11.0.4_9_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jdk_aarch64_linux_11.0.4_9_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_aarch64_linux_11.0.4_10_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_aarch64_linux_11.0.4_10_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jre_aarch64_linux_11.0.4_9_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B9/OpenJDK11U-jre_aarch64_linux_11.0.4_9_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_aarch64_linux_11.0.4_10_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_aarch64_linux_11.0.4_10_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -180,12 +180,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="2" class="first_col">OpenJDK 8 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">8u222-ea-b07</td>
+                <td colspan="2" class="bold midl">8u222-ea-b08</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">8u222-ea-b07</td>
+                <td colspan="2" class="bold midl">8u222-ea-b08</td>
                 <td rowspan="2" class="midl">
-                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8U-sources_8u222b07_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8U-sources_8u222b07_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-sources_8u222b08_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-sources_8u222b08_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -193,24 +193,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8U-jdk_x64_linux_8u222b07_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8U-jdk_x64_linux_8u222b07_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-jdk_x64_linux_8u222b08_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-jdk_x64_linux_8u222b08_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8U-jre_x64_linux_8u222b07_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8U-jre_x64_linux_8u222b07_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-jre_x64_linux_8u222b08_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-jre_x64_linux_8u222b08_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td class="arch no_right">x86_64</td>
                 <td class="no_left">
                     <!-- Windows x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8u-jdk_x64_windows_8u222b07_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8u-jdk_x64_windows_8u222b07_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8u-jdk_x64_windows_8u222b08_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8u-jdk_x64_windows_8u222b08_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8u-jre_x64_windows_8u222b07_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b07/OpenJDK8u-jre_x64_windows_8u222b07_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8u-jre_x64_windows_8u222b08_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8u-jre_x64_windows_8u222b08_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
The usual round of EA builds updates. JDK 8u222-b08 introduces new test failures in the `sanity.openjdk` suite. New tests got introduced between b07 and b08 some of them now fail as they
expose previously existing code issues.

See:
https://mail.openjdk.java.net/pipermail/jdk8u-dev/2019-June/009735.html 
https://mail.openjdk.java.net/pipermail/jdk8u-dev/2019-June/009667.html

That's an FYI. Test pipeline runs for this update:

https://ci.adoptopenjdk.net/blue/organizations/jenkins/UpstreamAutotest/detail/UpstreamAutotest/11/pipeline