### PR TITLE
[Upstream] Rename "Official Release" to "GA Release"

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -13,7 +13,7 @@
 provided, please report any bugs you may find to <a href="https://bugs.java.com/">https://bugs.java.com/</a>. If you are looking for the AdoptOpenJDK supported binaries then please find them <a href="./index.html">here</a>.</p>
     </div>
 
-    <h2>Official Release</h2>
+    <h2>General-Availability Release</h2>
 
     <div class="download">
         <table id="release">


### PR DESCRIPTION
There have been concerns voiced that "Official Release" has a
connotation of being the one-and-only release, discrediting
other OpenJDK releases. Use a more neutral wording.