### PR TITLE
Update to JDK 11.0.5+1 and JDK 8u232-b01 EA builds

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -134,13 +134,13 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="3" class="first_col">OpenJDK 11 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">11.0.4-ea+10</td>
+                <td colspan="2" class="bold midl">11.0.5-ea+1</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">11.0.4-ea+10</td>
+                <td colspan="2" class="bold midl">11.0.5-ea+1</td>
                 <td rowspan="3">
                     <!-- Source Tarball JDK 11 -->
-                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-sources_11.0.4_10_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-sources_11.0.4_10_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-sources_11.0.5_1_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-sources_11.0.5_1_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -148,24 +148,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_x64_linux_11.0.4_10_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_x64_linux_11.0.4_10_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jdk_x64_linux_11.0.5_1_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jdk_x64_linux_11.0.5_1_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_x64_linux_11.0.4_10_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_x64_linux_11.0.4_10_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jre_x64_linux_11.0.5_1_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jre_x64_linux_11.0.5_1_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td rowspan="2" class="arch no_right">x86_64</td>
                 <td rowspan="2" class="no_left">
                     <!-- Windows x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_x64_windows_11.0.4_10_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_x64_windows_11.0.4_10_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jdk_x64_windows_11.0.5_1_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jdk_x64_windows_11.0.5_1_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_x64_windows_11.0.4_10_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_x64_windows_11.0.4_10_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jre_x64_windows_11.0.5_1_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jre_x64_windows_11.0.5_1_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -174,12 +174,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux aarch64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_aarch64_linux_11.0.4_10_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jdk_aarch64_linux_11.0.4_10_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jdk_aarch64_linux_11.0.5_1_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jdk_aarch64_linux_11.0.5_1_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_aarch64_linux_11.0.4_10_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.4%2B10/OpenJDK11U-jre_aarch64_linux_11.0.4_10_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jre_aarch64_linux_11.0.5_1_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B1/OpenJDK11U-jre_aarch64_linux_11.0.5_1_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -192,12 +192,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="2" class="first_col">OpenJDK 8 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">8u222-ea-b08</td>
+                <td colspan="2" class="bold midl">8u232-ea-b01</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">8u222-ea-b08</td>
+                <td colspan="2" class="bold midl">8u232-ea-b01</td>
                 <td rowspan="2" class="midl">
-                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-sources_8u222b08_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-sources_8u222b08_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8U-sources_8u232b01_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8U-sources_8u232b01_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -205,24 +205,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-jdk_x64_linux_8u222b08_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-jdk_x64_linux_8u222b08_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8U-jdk_x64_linux_8u232b01_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8U-jdk_x64_linux_8u232b01_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-jre_x64_linux_8u222b08_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8U-jre_x64_linux_8u222b08_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8U-jre_x64_linux_8u232b01_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8U-jre_x64_linux_8u232b01_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td class="arch no_right">x86_64</td>
                 <td class="no_left">
                     <!-- Windows x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8u-jdk_x64_windows_8u222b08_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8u-jdk_x64_windows_8u222b08_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8u-jdk_x64_windows_8u232b01_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8u-jdk_x64_windows_8u232b01_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8u-jre_x64_windows_8u222b08_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u222-b08/OpenJDK8u-jre_x64_windows_8u222b08_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8u-jre_x64_windows_8u232b01_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b01/OpenJDK8u-jre_x64_windows_8u232b01_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
Tested with `sanity.openjdk` and `sanity.system`:

JDK 11.0.5+1:
https://ci.adoptopenjdk.net/blue/organizations/jenkins/UpstreamAutotest/detail/UpstreamAutotest/43/pipeline
aarch64 re-run: https://ci.adoptopenjdk.net/view/Test_upstream/job/Test_upstream_openjdk11_hs_sanity.openjdk_aarch64_linux/10/

JDK 8u232-b01: 
https://ci.adoptopenjdk.net/blue/organizations/jenkins/UpstreamAutotest/detail/UpstreamAutotest/39/pipeline

Linux `sanity.system` failure seems intermittent. Need to investigate. Windows locale failure (testbug) is being investigated and going to be fixed upstream.