### PR TITLE
Jelastic is added

### DIFF
--- a/src/handlebars/users.handlebars
+++ b/src/handlebars/users.handlebars
@@ -79,7 +79,11 @@
         <div class="clients">
           <img src="dist/assets/jclarity.png" alt="jClarity logo" />
         </div>
-
+        
+        <div class="clients">
+          <img src="https://jelastic.com/wp-content/themes/salient/img/logo.svg" alt="Jelastic logo" />
+        </div>
+        
         <div class="clients">
           <img src="https://dev.karakun.com/assets/logo.png" alt="Karakun logo" />
         </div>


### PR DESCRIPTION
Jelastic is now has AdoptOpenJDK binaries in a list of available JDKs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
