### PR TITLE
Update to JDK 11.0.5+6 and JDK 8u232-b05 EA builds

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -134,13 +134,13 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="3" class="first_col">OpenJDK 11 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">11.0.5-ea+5</td>
+                <td colspan="2" class="bold midl">11.0.5-ea+6</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">11.0.5-ea+5</td>
+                <td colspan="2" class="bold midl">11.0.5-ea+6</td>
                 <td rowspan="3">
                     <!-- Source Tarball JDK 11 -->
-                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-sources_11.0.5_5_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-sources_11.0.5_5_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-sources_11.0.5_6_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-sources_11.0.5_6_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -148,24 +148,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jdk_x64_linux_11.0.5_5_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jdk_x64_linux_11.0.5_5_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jdk_x64_linux_11.0.5_6_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jdk_x64_linux_11.0.5_6_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jre_x64_linux_11.0.5_5_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jre_x64_linux_11.0.5_5_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jre_x64_linux_11.0.5_6_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jre_x64_linux_11.0.5_6_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td rowspan="2" class="arch no_right">x86_64</td>
                 <td rowspan="2" class="no_left">
                     <!-- Windows x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jdk_x64_windows_11.0.5_5_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jdk_x64_windows_11.0.5_5_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jdk_x64_windows_11.0.5_6_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jdk_x64_windows_11.0.5_6_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jre_x64_windows_11.0.5_5_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jre_x64_windows_11.0.5_5_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jre_x64_windows_11.0.5_6_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jre_x64_windows_11.0.5_6_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -174,12 +174,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux aarch64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jdk_aarch64_linux_11.0.5_5_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jdk_aarch64_linux_11.0.5_5_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jdk_aarch64_linux_11.0.5_6_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jdk_aarch64_linux_11.0.5_6_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jre_aarch64_linux_11.0.5_5_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B5/OpenJDK11U-jre_aarch64_linux_11.0.5_5_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jre_aarch64_linux_11.0.5_6_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B6/OpenJDK11U-jre_aarch64_linux_11.0.5_6_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -192,12 +192,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="2" class="first_col">OpenJDK 8 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">8u232-ea-b04</td>
+                <td colspan="2" class="bold midl">8u232-ea-b05</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">8u232-ea-b04</td>
+                <td colspan="2" class="bold midl">8u232-ea-b05</td>
                 <td rowspan="2" class="midl">
-                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8U-sources_8u232b04_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8U-sources_8u232b04_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8U-sources_8u232b05_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8U-sources_8u232b05_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -205,24 +205,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8U-jdk_x64_linux_8u232b04_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8U-jdk_x64_linux_8u232b04_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8U-jdk_x64_linux_8u232b05_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8U-jdk_x64_linux_8u232b05_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8U-jre_x64_linux_8u232b04_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8U-jre_x64_linux_8u232b04_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8U-jre_x64_linux_8u232b05_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8U-jre_x64_linux_8u232b05_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td class="arch no_right">x86_64</td>
                 <td class="no_left">
                     <!-- Windows x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8u-jdk_x64_windows_8u232b04_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8u-jdk_x64_windows_8u232b04_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8u-jdk_x64_windows_8u232b05_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8u-jdk_x64_windows_8u232b05_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8u-jre_x64_windows_8u232b04_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b04/OpenJDK8u-jre_x64_windows_8u232b04_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8u-jre_x64_windows_8u232b05_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b05/OpenJDK8u-jre_x64_windows_8u232b05_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
Another round of upstream project builds update. Testing links:

JDK 11: https://ci.adoptopenjdk.net/blue/organizations/jenkins/UpstreamAutotest/detail/UpstreamAutotest/77/pipeline/64
JDK 8: https://ci.adoptopenjdk.net/blue/organizations/jenkins/UpstreamAutotest/detail/UpstreamAutotest/80/pipeline/