### PR TITLE
Mention that Red Hat builds the upstream project builds

### DIFF
--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -69,7 +69,7 @@
       </div>
     </a>
 
-    AdoptOpenJDK now also distributes Red Hat built <strong><a style="text-decoration: none;" href="./upstream.html">OpenJDK upstream builds</a></strong>!
+    AdoptOpenJDK now also distributes <strong><a style="text-decoration: none;" href="./upstream.html">OpenJDK upstream builds</a></strong>! (Built by Red Hat)
   </div>
 
   <div style="margin-top: 3rem;">

--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -69,7 +69,7 @@
       </div>
     </a>
 
-    AdoptOpenJDK now also distributes <strong><a style="text-decoration: none;" href="./upstream.html">OpenJDK upstream builds</a></strong>!
+    AdoptOpenJDK now also distributes Red Hat built <strong><a style="text-decoration: none;" href="./upstream.html">OpenJDK upstream builds</a></strong>!
   </div>
 
   <div style="margin-top: 3rem;">


### PR DESCRIPTION
I've been asked to add "Red Hat built" for the upstream reference on the index page.