### PR TITLE
Update to JDK 11.0.5+8 EA builds

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -134,13 +134,13 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="3" class="first_col">OpenJDK 11 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">11.0.5-ea+7</td>
+                <td colspan="2" class="bold midl">11.0.5-ea+8</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">11.0.5-ea+7</td>
+                <td colspan="2" class="bold midl">11.0.5-ea+8</td>
                 <td rowspan="3">
                     <!-- Source Tarball JDK 11 -->
-                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-sources_11.0.5_7_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-sources_11.0.5_7_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-sources_11.0.5_8_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-sources_11.0.5_8_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -148,24 +148,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jdk_x64_linux_11.0.5_7_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jdk_x64_linux_11.0.5_7_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jdk_x64_linux_11.0.5_8_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jdk_x64_linux_11.0.5_8_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jre_x64_linux_11.0.5_7_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jre_x64_linux_11.0.5_7_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jre_x64_linux_11.0.5_8_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jre_x64_linux_11.0.5_8_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td rowspan="2" class="arch no_right">x86_64</td>
                 <td rowspan="2" class="no_left">
                     <!-- Windows x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jdk_x64_windows_11.0.5_7_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jdk_x64_windows_11.0.5_7_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jdk_x64_windows_11.0.5_8_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jdk_x64_windows_11.0.5_8_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jre_x64_windows_11.0.5_7_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jre_x64_windows_11.0.5_7_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jre_x64_windows_11.0.5_8_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jre_x64_windows_11.0.5_8_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -174,12 +174,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux aarch64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jdk_aarch64_linux_11.0.5_7_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jdk_aarch64_linux_11.0.5_7_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jdk_aarch64_linux_11.0.5_8_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jdk_aarch64_linux_11.0.5_8_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jre_aarch64_linux_11.0.5_7_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B7/OpenJDK11U-jre_aarch64_linux_11.0.5_7_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jre_aarch64_linux_11.0.5_8_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B8/OpenJDK11U-jre_aarch64_linux_11.0.5_8_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
New round of upstream JDK 11 builds. Testing looks good:

https://ci.adoptopenjdk.net/blue/organizations/jenkins/UpstreamAutotest/detail/UpstreamAutotest/94/pipeline/61