### PR TITLE
Update to JDK 8u232-b08 EA builds

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -192,12 +192,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="2" class="first_col">OpenJDK 8 EA</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">8u232-ea-b07</td>
+                <td colspan="2" class="bold midl">8u232-ea-b08</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">8u232-ea-b07</td>
+                <td colspan="2" class="bold midl">8u232-ea-b08</td>
                 <td rowspan="2" class="midl">
-                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8U-sources_8u232b07_ea.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8U-sources_8u232b07_ea.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8U-sources_8u232b08_ea.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8U-sources_8u232b08_ea.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -205,24 +205,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8U-jdk_x64_linux_8u232b07_ea.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8U-jdk_x64_linux_8u232b07_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8U-jdk_x64_linux_8u232b08_ea.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8U-jdk_x64_linux_8u232b08_ea.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8U-jre_x64_linux_8u232b07_ea.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8U-jre_x64_linux_8u232b07_ea.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8U-jre_x64_linux_8u232b08_ea.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8U-jre_x64_linux_8u232b08_ea.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td class="arch no_right">x86_64</td>
                 <td class="no_left">
                     <!-- Windows x86_64 JDK 8 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8u-jdk_x64_windows_8u232b07_ea.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8u-jdk_x64_windows_8u232b07_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8u-jdk_x64_windows_8u232b08_ea.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8u-jdk_x64_windows_8u232b08_ea.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8u-jre_x64_windows_8u232b07_ea.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b07/OpenJDK8u-jre_x64_windows_8u232b07_ea.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8u-jre_x64_windows_8u232b08_ea.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u232-b08/OpenJDK8u-jre_x64_windows_8u232b08_ea.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
Latest round of JDK 8u EA builds. No changes for JDK 11u.