### PR TITLE
rename windows x32 to windows x86

### DIFF
--- a/src/json/config.json
+++ b/src/json/config.json
@@ -136,7 +136,7 @@
       "osDetectionString": "not-to-be-detected"
     },
     {
-      "officialName": "Windows x32",
+      "officialName": "Windows x86",
       "searchableName": "X32_WIN",
       "attributes": {
         "heap_size": "normal",


### PR DESCRIPTION
fixes: https://github.com/AdoptOpenJDK/openjdk-website/issues/605