### PR TITLE
noscript - make menu open and close without JS

### DIFF
--- a/src/handlebars/partials/header.handlebars
+++ b/src/handlebars/partials/header.handlebars
@@ -69,7 +69,9 @@
 <body class="blue-bg">
   {{> menu }}
   <nav>
-      <i id="menu-button" class="fa fa-bars" aria-hidden="true"></i>
+      <label id="menu-button" for="menu-checkbox">
+        <i class="fa fa-bars" aria-hidden="true"></i>
+      </label>
       <a id="logo" href="./index.html" class="a-button">
           <img src='dist/assets/adopt_logo_white.svg' alt="AdoptOpenJDK">
       </a>

--- a/src/handlebars/partials/menu.handlebars
+++ b/src/handlebars/partials/menu.handlebars
@@ -1,6 +1,9 @@
-<div id="menu-container" class="grey-bg hide slideInLeft">
+<input type="checkbox" id="menu-checkbox" class="hide" />
+<div id="menu-container" class="grey-bg slideInLeft">
   <div id="menu-header">
+    <label for="menu-checkbox">
       <i id="menu-close" class="fa fa-arrow-circle-left" aria-hidden="true"></i>
+    </label>
   </div>
   <div id="menu-content">
     <ul>

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -9,20 +9,6 @@ platforms.forEach((platform) => lookup[platform.searchableName] = platform);
 let variant = module.exports.variant = getQueryByName('variant') || 'openjdk8';
 let jvmVariant = module.exports.jvmVariant = getQueryByName('jvmVariant') || 'hotspot';
 
-// set variable names for menu elements
-const menuOpen = document.getElementById('menu-button');
-const menuClose = document.getElementById('menu-close');
-const menu = document.getElementById('menu-container');
-
-menuOpen.onclick = () => {
-  menu.className = menu.className.replace(/(?:^|\s)slideOutLeft(?!\S)/g, ' slideInLeft'); // slide in animation
-  menu.className = menu.className.replace(/(?:^|\s)hide(?!\S)/g, ' animated'); // removes initial hidden property, activates animations
-}
-
-menuClose.onclick = () => {
-  menu.className = menu.className.replace(/(?:^|\s)slideInLeft(?!\S)/g, ' slideOutLeft'); // slide out animation
-}
-
 module.exports.getVariantObject = (variantName) => variants.find((variant) => variant.searchableName === variantName);
 
 module.exports.findPlatform = (binaryData) => {

--- a/src/scss/styles-1-large-main.scss
+++ b/src/scss/styles-1-large-main.scss
@@ -258,6 +258,10 @@ nav {
   color: $brighterblue;
 }
 
+#menu-checkbox:not(:checked) + * {
+  display: none;
+}
+
 #menu-content {
   overflow: auto;
   height: 80%;


### PR DESCRIPTION
Some people like to browse with JS turned off. Making the menu open and close without JS is a relatively trivial thing, using HTML and CSS.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
