### PR TITLE
More clarity for why choose OpenJ9

### DIFF
--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -32,7 +32,7 @@
             <div class="popup-text">
               <p class="hotspot-text"><b>HotSpot</b> is the VM from the OpenJDK community. It is the most widely used VM today and is used in Oracle’s JDK. It is suitable for all workloads.</p>
               <p>For more details see <a target="_blank" href="https://openjdk.java.net/groups/hotspot/">OpenJDK HotSpot</a>.</p>
-              <p class="openj9-text"><b>Eclipse OpenJ9</b> is the VM from the Eclipse community.  It is an enterprise-grade VM designed for low memory usage and fast start-up and is used in IBM’s JDK.  It is suitable for running all workloads.</p>
+              <p class="openj9-text"><b>Eclipse OpenJ9</b> is the VM from the Eclipse community.  It is an enterprise-grade VM designed for low memory footprint and fast start-up and is used in IBM’s JDK.  It is suitable for running all workloads.</p>
               <p>For more details see <a target="_blank" href="https://www.eclipse.org/openj9/">Eclipse OpenJ9</a>.</p>
               <p class="lts-text"><b>LTS</b> (Long Term Support). These versions have a longer support timeframe. Suitable for enterprise customers. See <a href="./support.html">Support</a> for more information.</p>
             </div>


### PR DESCRIPTION
Existing explanation implies that OpenJ9 is designed for
low memory usage and you might not choose it if your app
requires a lot of memory. Change the word "usage" to "footprint"
for more clarity.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
