### PR TITLE
Add January 2020 CPU builds for JDK 11 to upstream.html

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -26,13 +26,13 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
             <tr>
                 <td rowspan="3" class="first_col">OpenJDK 11</td>
                 <!-- Linux version -->
-                <td colspan="2" class="bold midl">11.0.5+10</td>
+                <td colspan="2" class="bold midl">11.0.6+10</td>
                 <!-- Windows version -->
-                <td colspan="2" class="bold midl">11.0.5+10</td>
+                <td colspan="2" class="bold midl">11.0.6+10</td>
                 <td rowspan="3">
                     <!-- Source Tarball JDK 11 -->
-                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-sources_11.0.5_10.tar.gz">Source Tarball</a>
-                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-sources_11.0.5_10.tar.gz.sign">signature</a>)
+                    <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-sources_11.0.6_10.tar.gz">Source Tarball</a>
+                    (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-sources_11.0.6_10.tar.gz.sign">signature</a>)
                 </td>
             </tr>
             <tr>
@@ -40,24 +40,24 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_linux_11.0.5_10.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_linux_11.0.5_10.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_11.0.6_10.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_11.0.6_10.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jre_x64_linux_11.0.5_10.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jre_x64_linux_11.0.5_10.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_11.0.6_10.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_11.0.6_10.tar.gz.sign">signature</a>)
                     </div>
                 </td>
                 <td rowspan="2" class="arch no_right">x86_64</td>
                 <td rowspan="2" class="no_left">
                     <!-- Windows x86_64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_windows_11.0.5_10.zip">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_windows_11.0.5_10.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_windows_11.0.6_10.zip">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_windows_11.0.6_10.zip.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jre_x64_windows_11.0.5_10.zip">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jre_x64_windows_11.0.5_10.zip.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_windows_11.0.6_10.zip">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_windows_11.0.6_10.zip.sign">signature</a>)
                     </div>
                 </td>
             </tr>
@@ -66,12 +66,12 @@ provided, please report any bugs you may find to <a href="https://bugs.java.com/
                 <td class="no_left">
                     <!-- Linux aarch64 JDK 11 -->
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_aarch64_linux_11.0.5_10.tar.gz">JDK</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_aarch64_linux_11.0.5_10.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_aarch64_linux_11.0.6_10.tar.gz">JDK</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_aarch64_linux_11.0.6_10.tar.gz.sign">signature</a>)
                     </div>
                     <div>
-                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jre_aarch64_linux_11.0.5_10.tar.gz">JRE</a>
-                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jre_aarch64_linux_11.0.5_10.tar.gz.sign">signature</a>)
+                        <a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_aarch64_linux_11.0.6_10.tar.gz">JRE</a>
+                        (<a href="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_aarch64_linux_11.0.6_10.tar.gz.sign">signature</a>)
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
GA tag for JDK 11:   jdk-11.0.6+10

Upstream release announcement:
http://mail.openjdk.java.net/pipermail/jdk-updates-dev/2020-January/002374.html

Testing at AdoptOpenJDK in progress here:
https://ci.adoptopenjdk.net/blue/organizations/jenkins/UpstreamAutotest/detail/UpstreamAutotest/225/pipeline