### PR TITLE
Fix typo on apt-get command

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -332,7 +332,7 @@
       <pre><code class="highlighted">apt-get install -y software-properties-common</code></pre>
 
       <p>Then repeat the first command.</p>
-      <p>3. Refresh your package list with <tt>apt-get-update</tt> and then install your chosen AdoptOpenJDK package. For example, to
+      <p>3. Refresh your package list with <tt>apt-get update</tt> and then install your chosen AdoptOpenJDK package. For example, to
         install OpenJDK 8 with the HotSpot VM, run:</p>
       <pre><code class="highlighted">apt-get install &lt;adoptopenjdk-8-hotspot&gt;</code></pre>
 


### PR DESCRIPTION
Fix typo: `apt-get-update` to `apt-get update`

##### Checklist

- [x ] documentation is changed or added (if applicable)
