### PR TITLE
Fix CentOS repository example

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -349,7 +349,7 @@
        </p>
        <p>1. Add the appropriate RPM repository to your <tt>/etc/yum.repos.d/adoptopenjdk.repo</tt> file, by running the following command:</p>
        <pre><code class="highlighted">
-cat &lt;&lt;EOF &gt; /etc/yum.repos.d/adoptopenjdk.repo
+cat &lt;&lt;&apos;EOF&apos; &gt; /etc/yum.repos.d/adoptopenjdk.repo
 [AdoptOpenJDK]
 name=AdoptOpenJDK
 baseurl=http://adoptopenjdk.jfrog.io/adoptopenjdk/rpm/centos/$releasever/$basearch


### PR DESCRIPTION
Follow up for #683.

Add single quotes to here document to disable variable replacement on shell.

Use yum variables for repository configuration, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sec-using_yum_variables

##### Checklist

- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
