### PR TITLE
[WIP] Update Java 8 end of availability

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -84,7 +84,7 @@
               <strong>jdk8u252<br/>
               14th April 2020</strong>
           </td>
-          <td><strong>At Least Sept 2023 <sup>[1]</sup></strong></td>
+          <td><strong>At Least May 2026 <sup>[1]</sup></strong></td>
         </tr>
         <tr>
           <td>Java 9</td>


### PR DESCRIPTION
Changed the end of availability for AdoptOpenJDK 8 binaries to match the public dates for Red Hat's (OpenJDK 8u stewards) end of support for OpenJDK 8.
https://access.redhat.com/articles/1299013

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
