### PR TITLE
Update Java 14 availability and Java 11 EOS dates

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -111,7 +111,7 @@
             <strong>jdk-11.0.7<br/>
             14th April 2020</strong>
           </td>
-          <td><strong>At Least Sept 2022 <sup>[1]</sup></strong></td>
+          <td><strong>At Least Oct 2024 <sup>[1]</sup></strong></td>
         </tr>
         <tr>
           <td>Java 12</td>
@@ -133,11 +133,11 @@
         <tr>
           <td>Java 14</td>
           <td>March 2020</td>
-          <td>N/A</td>
           <td>
-            <strong>jdk-14<br/>
-              17th March 2020</strong>
+            <strong>jdk-14+36<br/>
+              18th March 2020</strong>
           </td>
+          <td>TBD</td>
           <td>Sept 2020</td>
         </tr>
 


### PR DESCRIPTION
Update to availability dates.
For Java 11 date move see https://github.com/AdoptOpenJDK/TSC/issues/145