### PR TITLE
Use sudo for all apt commands

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -331,12 +331,12 @@
       <pre><code class="highlighted">sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/</code></pre>
 
       <p>If you get a <q>command not found</q> error, try running:</p>
-      <pre><code class="highlighted">apt-get install -y software-properties-common</code></pre>
+      <pre><code class="highlighted">sudo apt-get install -y software-properties-common</code></pre>
 
       <p>Then repeat the first command.</p>
-      <p>3. Refresh your package list with <tt>apt-get update</tt> and then install your chosen AdoptOpenJDK package. For example, to
+      <p>3. Refresh your package list with <tt>sudo apt-get update</tt> and then install your chosen AdoptOpenJDK package. For example, to
         install OpenJDK 8 with the HotSpot VM, run:</p>
-      <pre><code class="highlighted">apt-get install &lt;adoptopenjdk-8-hotspot&gt;</code></pre>
+      <pre><code class="highlighted">sudo apt-get install &lt;adoptopenjdk-8-hotspot&gt;</code></pre>
 
     <h4 id="linux-pkg-rpm">RPM installation</h4>
 


### PR DESCRIPTION
Was authoring a "howto" YouTube video and discovered that some commands are missing `sudo` whereas others have `sudo`.

This PR uses `sudo` in all apt examples for consistency:

> ![image](https://user-images.githubusercontent.com/6345473/77089670-7e3efc00-69dc-11ea-8eac-c14d0c0e191a.png)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->