### PR TITLE
allow website to show ea builds

### DIFF
--- a/src/handlebars/releases.handlebars
+++ b/src/handlebars/releases.handlebars
@@ -64,7 +64,11 @@
                     <tr>
                        <td class="main-download__variant__name blue-bg">
                           <span>\{{release_name}}</span>
+                          \{{#if early_access}}
+                          <span class="early-access">AdoptOpenJDK</span>
+                          \{{else}}
                           <span class="download-last-version">AdoptOpenJDK</span>
+                          \{{/if}}
                        </td>
                        <td class="main-download__variant__os">
                           <span class="os">\{{fetchOS platform_official_name}}</span>

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -101,7 +101,7 @@ module.exports.detectLTS = (version) => {
 }
 
 module.exports.detectEA = (version) => {
-  if (version.includes('-ea')) {
+  if ((version.pre) && (version.pre == 'ea')) {
     return true
   } else { 
     return false

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -100,6 +100,14 @@ module.exports.detectLTS = (version) => {
   }
 }
 
+module.exports.detectEA = (version) => {
+  if (version.includes('-ea')) {
+    return true
+  } else { 
+    return false
+  }
+}
+
 function toJson(response) {
   while (typeof response === 'string') {
     try {

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -1,5 +1,5 @@
 const {findPlatform, getBinaryExt, getInstallerExt, getSupportedVersion, getOfficialName, getPlatformOrder,
-    getVariantObject, detectLTS, loadLatestAssets, orderPlatforms, setRadioSelectors, setTickLink} = require('./common');
+    getVariantObject, detectLTS, detectEA, loadLatestAssets, orderPlatforms, setRadioSelectors, setTickLink} = require('./common');
 const {jvmVariant, variant} = require('./common');
 
 const loading = document.getElementById('loading');
@@ -88,7 +88,7 @@ function buildLatestHTML(releasesJson) {
         heap_size: heap_size,
         release_link: releaseAsset.release_link,
         release_datetime: moment(releaseAsset.timestamp).format('YYYY-MM-DD hh:mm:ss'),
-
+        early_access: detectEA(releaseAsset.release_name),
         binaries: []
       };
     }

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -75,7 +75,6 @@ function buildLatestHTML(releasesJson) {
     if (!['INSTALLER', 'JDK', 'JRE'].includes(binary_type)) {
       return;
     }
-
     // Get the existing release asset (passed to the template) or define a new one
     let release = releases.find((release) => release.platform_name === platform);
     if (!release) {
@@ -88,7 +87,7 @@ function buildLatestHTML(releasesJson) {
         heap_size: heap_size,
         release_link: releaseAsset.release_link,
         release_datetime: moment(releaseAsset.timestamp).format('YYYY-MM-DD hh:mm:ss'),
-        early_access: detectEA(releaseAsset.release_name),
+        early_access: detectEA(releaseAsset.version),
         binaries: []
       };
     }

--- a/src/scss/styles-4-releases.scss
+++ b/src/scss/styles-4-releases.scss
@@ -136,6 +136,31 @@ div#latest-selector {
     font-size: 14px;
 }
 
+.early-access:after {
+    width: 75px;
+    line-height: 19px;
+    -webkit-border-radius: 3px;
+    border-radius: 3px;
+    background-color: red;
+    margin-left: 9px;
+    color: #ffffff;
+    font-size: 12px;
+    font-weight: 400;
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    -webkit-box-align: center;
+    -webkit-align-items: center;
+    -ms-flex-align: center;
+    align-items: center;
+    content: "early access" !important;
+}
+
 .download-last-version:after {
     width: 42px;
     line-height: 19px;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)

This PR adds an early access tag:

```js
  if ((version.pre) && (version.pre == 'ea')) {
    return true
  } else { 
    return false
  }
```
Sample:
![Screenshot 2020-04-08 at 11 36 29](https://user-images.githubusercontent.com/20224954/78775220-c1faa500-798d-11ea-97b7-a97b51200f98.png)

