### PR TITLE
Update migration page for OpenJFX

### DIFF
--- a/src/handlebars/migration.handlebars
+++ b/src/handlebars/migration.handlebars
@@ -48,7 +48,7 @@
             <td>JavaFX</td>
             <td><a href="#openjfx">OpenJFX</a></td>
             <td><i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">no</span></td>
-            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">no</span> (coming soon)</td>
+            <td><i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">no</span></td>
           </tr>
           <tr>
             <td>T2K font rendering engine</td>
@@ -130,8 +130,9 @@
 
       <h3 id="openjfx">OpenJFX</h3>
 
-      <p>Back in 2017, JavaFX was decoupled from the Oracle JDK and contributed to the OpenJDK community. The OpenJFX community is focused on OpenJFX 11+ and AdoptOpenJDK is working with the OpenJFX community to provide it via an installer option in AdoptOpenJDK binaries.</p>
-      <p><i class="fa fa-pencil" aria-hidden="true"></i><span class="sr-only">Note:</span> OpenJFX 8 is no longer being actively maintained. If you need this capability, we recommend upgrading to OpenJFX 11.</p>
+      <p>Back in 2017, JavaFX was decoupled from the Oracle JDK and contributed to the OpenJDK community. The OpenJFX community is focused on OpenJFX 11+ and provides binaries that you can use with AdoptOpenJDK.  </p>
+      <p>OpenJFX 8 is no longer being actively maintained. If you need this capability, we recommend upgrading to OpenJFX 11.</p>
+      <p>For more information, read the <a href="./faq.html#openjfxfaq">OpenJFX FAQ</a>.</p>
 
       <h3 id="freetype-font-rendering-library">Freetype font rendering library</h3>
 


### PR DESCRIPTION
Migration page still shows OpenJFX as "coming soon".
Modified the table to remove "coming soon" and changed the content in the OpenJFX section.
Link users to the OpenJFX FAQ.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
