### PR TITLE
Adjust minimum AIX level for OpenJ9 bulids to 7.1.5.5

### DIFF
--- a/src/handlebars/supported_platforms.handlebars
+++ b/src/handlebars/supported_platforms.handlebars
@@ -191,6 +191,10 @@
             <tbody>
                 <tr>
                     <td>AIX 7.1 TL4</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>AIX 7.1 TL5 SP5</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                 </tr>
                 <tr>
@@ -407,11 +411,15 @@
             <tbody>
                 <tr>
                     <td>AIX 7.1 TL4</td>
-                    <td><i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>AIX 7.1 TL5 SP5</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                 </tr>
                 <tr>
                     <td>AIX 7.2</td>
-                    <td><i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                 </tr>
             </tbody>
         </table>
@@ -797,14 +805,18 @@
         </tr>
         </thead>
         <tbody>
-        <tr>
-          <td>AIX 7.1 TL4</td>
-          <td><i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
-        </tr>
-        <tr>
-          <td>AIX 7.2</td>
-          <td><i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
-        </tr>
+          <tr>
+            <td>AIX 7.1 TL4</td>
+            <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+          </tr>
+          <tr>
+            <td>AIX 7.1 TL5 SP5</td>
+            <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+          </tr>
+          <tr>
+            <td>AIX 7.2</td>
+            <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
AIX builds of OpenJ9 will now only run on AIX 7.1.5.5 or later as we had to change the build machines in order to support some new functionality (That level has an updated version of the `dump` command)

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
