### PR TITLE
Add RHEL/CentOS8 as supported platforms

### DIFF
--- a/src/handlebars/supported_platforms.handlebars
+++ b/src/handlebars/supported_platforms.handlebars
@@ -64,6 +64,13 @@
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
+                    <td>Centos 8</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
                     <td>Red Hat Enterprise Linux (RHEL) 6.9</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                     <td></td>
@@ -72,6 +79,13 @@
                 </tr>
                 <tr>
                     <td>RHEL 7.4</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>RHEL 8</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
@@ -278,6 +292,14 @@
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
                 </tr>
                 <tr>
+                    <td>Centos 8</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td></td>
+                    <td></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
                     <td>RHEL 6.9</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                     <td></td>
@@ -287,6 +309,14 @@
                 </tr>
                 <tr>
                     <td>RHEL 7.4</td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+                    <td></td>
+                    <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+                </tr>
+                <tr>
+                    <td>RHEL 8</td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
                     <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
@@ -674,6 +704,14 @@
           <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
         </tr>
         <tr>
+          <td>Centos 8</td>
+          <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+          <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+          <td></td>
+          <td></td>
+          <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+        </tr>
+        <tr>
           <td>RHEL 6.9</td>
           <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
           <td></td>
@@ -683,6 +721,14 @@
         </tr>
         <tr>
           <td>RHEL 7.4</td>
+          <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+          <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+          <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
+          <td></td>
+          <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span></td>
+        </tr>
+        <tr>
+          <td>RHEL 8</td>
           <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
           <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>
           <td><i class="fa fa-star-o hotspot" aria-hidden="true"></i><span class="sr-only">Hotspot VM</span> <i class="fa fa-star-o openj9" aria-hidden="true"></i><span class="sr-only">OpenJ9 VM</span></td>


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>
- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)

CentOS8 is not yet available on s390x but this will add RHEL8. @smlambert I explicitly want your confirmation that you're happy with this before adding it given that we don't have systems running this level across ll platforms at present.