### PR TITLE
Remove menu option for Meeting diary

### DIFF
--- a/src/handlebars/partials/menu.handlebars
+++ b/src/handlebars/partials/menu.handlebars
@@ -28,7 +28,6 @@
           <li><a href="./testimonials.html">Testimonials</a></li>
           <li><a target="_blank" href="https://api.adoptopenjdk.net">API</a></li>
           <li><a target="_blank" href="https://blog.adoptopenjdk.net/">Blog</a></li>
-          <li><a target="_blank" href="https://calendar.adoptopenjdk.net/">Meeting diary</a></li>
           <li><a target="_blank" href="https://status.adoptopenjdk.net/">Status</a></li>
           <li><a href="./quality.html">Quality</a></li>
           <li><a href="./supported_platforms.html">Supported Platforms</a></li>


### PR DESCRIPTION
The project calendar is not used, and choosing this menu option results in ERR_NAME_NOT_RESOLVED.

Closes #643
