### PR TITLE
Standardise Month Naming on support.html

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -91,7 +91,7 @@
         </tr>
         <tr>
           <td>Java 9</td>
-          <td>Sept 2017</td>
+          <td>September 2017</td>
           <td>N/A</td>
           <td>N/A</td>
           <td>March 2018</td>
@@ -101,11 +101,11 @@
           <td>March 2018</td>
           <td>N/A</td>
           <td>N/A</td>
-          <td>Sept 2018</td>
+          <td>September 2018</td>
         </tr>
         <tr>
           <td><strong>Java 11 (LTS)</strong></td>
-          <td><strong>Sept 2018</strong></td>
+          <td><strong>September 2018</strong></td>
           <td>
             <strong>jdk-11.0.9+11<br/>
               20th October 2021</strong>
@@ -121,11 +121,11 @@
           <td>March 2019</td>
           <td>N/A</td>
           <td>N/A</td>
-          <td>Sept 2019</td>
+          <td>September 2019</td>
         </tr>
         <tr>
           <td>Java 13</td>
-          <td>Sept 2019</td>
+          <td>September 2019</td>
           <td>
             <strong>jdk-13.0.2+8<br/>
               14th January 2020</strong>


### PR DESCRIPTION
The Support page contains variations of Sept and September and no standardisation in month naming. This PR changes all instances of `Sept` on the support page to `September`

Signed-off-by: Morgan Davies morgandavies2020@gmail.com

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [x] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
