### PR TITLE
Add JSON schema definition for platform.attributes object

### DIFF
--- a/src/json/config.schema.json
+++ b/src/json/config.schema.json
@@ -84,7 +84,8 @@
           "pathCommand",
           "checksumCommand",
           "checksumAutoCommand",
-          "osDetectionString"
+          "osDetectionString",
+          "attributes"
         ],
         "properties": {
           "officialName": {
@@ -162,6 +163,48 @@
               { "pattern": "^([^\\s]+\\s?)+$" },
               { "const": "not-to-be-detected" }
             ]
+          },
+          "attributes": {
+            "$id": "#/properties/platforms/items/properties/attributes",
+            "type": "object",
+            "required": [
+              "heap_size",
+              "os",
+              "architecture"
+            ],
+            "properties": {
+              "heap_size": {
+                "type": "string",
+                "enum": [
+                  "normal",
+                  "large"
+                ]
+              },
+              "os": {
+                "type": "string",
+                "enum": [
+                  "aix",
+                  "linux",
+                  "mac",
+                  "solaris",
+                  "windows"
+                ]
+              },
+              "architecture": {
+                "type": "string",
+                "enum": [
+                  "aarch64",
+                  "arm",
+                  "ppc64",
+                  "ppc64le",
+                  "riscv64",
+                  "s390x",
+                  "sparcv9",
+                  "x32",
+                  "x64"
+                ]
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR adds a schema definition for the `platform.attributes` object used in `config.json`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
