### PR TITLE
Move ojdkbuild reference to correct section

### DIFF
--- a/src/handlebars/faq.handlebars
+++ b/src/handlebars/faq.handlebars
@@ -284,16 +284,16 @@
 
          <p>There are versions of <a href="https://www.azul.com/downloads/zulu-community/">Azul Zulu</a> and
          <a href="https://bell-sw.com/java8">BellSoft Liberica</a> that include JavaFX and are available free of
-         charge.</p>
+         charge. The <a href="https://github.com/ojdkbuild/ojdkbuild">ojdkbuild</a> project
+         <a href="https://github.com/ojdkbuild/ojdkbuild/releases">offers JDK 8 builds with patched OpenJFX 8 overlays
+         for Windows</a> (<a href="https://github.com/ojdkbuild/upstream_openjfx-8u">sources</a>).</p>
     <dt> <strong>What are my options if I need patches or support for OpenJFX 11 or later?</strong>
     <dd> <p><a href="https://gluonhq.com/services/javafx-support/">Gluon</a>, the main contributor to OpenJFX,
          provides LTS support for OpenJFX 11.</p>
 
          <p>There are versions of <a href="https://www.azul.com/downloads/zulu-community/">Azul Zulu</a> and
          <a href="https://bell-sw.com/java8">BellSoft Liberica</a> that include JavaFX and are available free of
-         charge. The <a href="https://github.com/ojdkbuild/ojdkbuild">ojdkbuild</a> project
-         <a href="https://github.com/ojdkbuild/ojdkbuild/releases">offers JDK 8 builds with patched OpenJFX 8 overlays
-         for Windows</a> (<a href="https://github.com/ojdkbuild/upstream_openjfx-8u">sources</a>).</p>
+         charge.</p>
     <dt> <strong>What would be required to get AdoptOpenJDK to include OpenJFX?</strong>
     <dd> <p>If a credible interest group stepped up to provide long term support for OpenJFX that follows the
          release schedule of OpenJDK, we would consider bundling OpenJFX. If you want to support or sponsor such


### PR DESCRIPTION
The change in #855 went into the section for OpenJFX 11 instead of the section for OpenJFX 8 :facepalm:. This is now fixed.