### PR TITLE
Reduce duplicate data in config.json

### DIFF
--- a/src/js/common.js
+++ b/src/js/common.js
@@ -1,6 +1,6 @@
 // prefix for assets (e.g. logo)
 
-const {platforms, variants} = require('../json/config');
+const {platforms, installCommands, variants} = require('../json/config');
 
 // Enables things like 'lookup["X64_MAC"]'
 const lookup = {};
@@ -76,20 +76,33 @@ module.exports.getSupportedVersion = (searchableName) => {
   return supported_version
 }
 
-// gets the INSTALLATION COMMAND when you pass in 'searchableName'
-module.exports.getInstallCommand = (searchableName) => lookup[searchableName].installCommand;
+// gets the INSTALLATION COMMANDS when you pass in 'os'
+module.exports.getInstallCommands = (os) => {
+  let installObject
+  switch(os) {
+    case 'windows':
+      installObject = fetchInstallObject('powershell')
+      break;
+    case 'aix':
+      installObject = fetchInstallObject('gunzip')
+      break;
+    case 'solaris':
+      installObject = fetchInstallObject('gunzip')
+      break;
+    default:
+      // defaults to tar installation
+      installObject = fetchInstallObject('tar')
+  }
+  return installObject
+}
 
-// gets the CHECKSUM COMMAND when you pass in 'searchableName'
-module.exports.getChecksumCommand = (searchableName) => lookup[searchableName].checksumCommand;
-
-// gets the CHECKSUM AUTO COMMAND HINT when you pass in 'searchableName'
-module.exports.getChecksumAutoCommandHint = (searchableName) => lookup[searchableName].checksumAutoCommandHint;
-
-// gets the CHECKSUM AUTO COMMAND when you pass in 'searchableName'
-module.exports.getChecksumAutoCommand = (searchableName) => lookup[searchableName].checksumAutoCommand;
-
-// gets the PATH COMMAND when you pass in 'searchableName'
-module.exports.getPathCommand = (searchableName) => lookup[searchableName].pathCommand;
+function fetchInstallObject(command) {
+  for (let installCommand of installCommands){
+    if (command == installCommand.name) {
+      return installCommand
+    }
+  }
+}
 
 // This function returns an object containing all information about the user's OS.
 // The OS info comes from the 'platforms' array, which in turn comes from 'config.json'.

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -11,7 +11,7 @@ let defaultVariant;
 // Set the default JDK based on config.json
 for (let variant of variants) {
   if (variant.default) {
-    defaultVariant = variant.searchableName.split('-')[0]
+    defaultVariant = variant.searchableName;
   }
 }
 
@@ -329,7 +329,7 @@ module.exports.setRadioSelectors = () => {
           btnLabel.innerHTML += `<span>${variant.label}</span>`;
         }
       } else {
-        btnLabel.innerHTML += `<span>${variant.jvm}</span>`;
+        btnLabel.innerHTML += `<span>${variant}</span>`;
       }
 
       element.appendChild(btnLabel);
@@ -338,12 +338,13 @@ module.exports.setRadioSelectors = () => {
   }
 
   for (let variant of variants) {
-    const splitVariant = variant.searchableName.split('-');
-    const jdkName = splitVariant[0];
-    const jvmName = splitVariant[1];
-    createRadioButtons(jdkName, 'jdk', variant, jdkSelector);
-    if (jvmSelector) {
-      createRadioButtons(jvmName, 'jvm', variant, jvmSelector);
+    for (let jvmVariantOption of variant.jvm) {
+      const jdkName =  variant.searchableName;
+      const jvmName = jvmVariantOption.toLowerCase();
+      createRadioButtons(jdkName, 'jdk', variant, jdkSelector);
+      if (jvmSelector) {
+        createRadioButtons(jvmName, 'jvm', jvmVariantOption, jvmSelector);
+      }
     }
   }
 

--- a/src/js/installation.js
+++ b/src/js/installation.js
@@ -1,6 +1,4 @@
-const {detectOS, findPlatform, getChecksumCommand, getInstallCommand, getOfficialName,
-  getPathCommand, getPlatformOrder, loadAssetInfo, orderPlatforms, setRadioSelectors, getChecksumAutoCommandHint,
-  getChecksumAutoCommand } = require('./common');
+const {detectOS, findPlatform, getInstallCommands, getOfficialName, getPlatformOrder, loadAssetInfo, orderPlatforms, setRadioSelectors} = require('./common');
 const {jvmVariant, variant} = require('./common');
 
 const loading = document.getElementById('loading');
@@ -32,21 +30,22 @@ function buildInstallationHTML(releasesJson) {
       ASSETOBJECT.thisPlatformOrder = getPlatformOrder(ASSETOBJECT.thisPlatform);
       ASSETOBJECT.thisOfficialName = getOfficialName(ASSETOBJECT.thisPlatform) + ' ' + eachAsset.image_type;
       ASSETOBJECT.thisPlatformType = (ASSETOBJECT.thisPlatform + '-' + eachAsset.image_type).toUpperCase();
-
       ASSETOBJECT.thisPlatformExists = true;
       ASSETOBJECT.thisBinaryLink = eachAsset.package.link;
       ASSETOBJECT.thisBinaryFilename = eachAsset.package.name;
       ASSETOBJECT.thisChecksum = eachAsset.package.checksum;
       ASSETOBJECT.thisChecksumLink = eachAsset.package.checksum_link;
       ASSETOBJECT.thisChecksumFilename = eachAsset.package.name.replace(ASSETOBJECT.thisBinaryExtension, '.sha256.txt');
-      ASSETOBJECT.thisUnzipCommand = getInstallCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
-      ASSETOBJECT.thisChecksumCommand = getChecksumCommand(ASSETOBJECT.thisPlatform).replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
+      ASSETOBJECT.os = eachAsset.os;
+      ASSETOBJECT.thisInstallCommands = getInstallCommands(ASSETOBJECT.os)
+      ASSETOBJECT.thisUnzipCommand = ASSETOBJECT.thisInstallCommands.installCommand.replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
+      ASSETOBJECT.thisChecksumCommand = ASSETOBJECT.thisInstallCommands.checksumCommand.replace('FILENAME', ASSETOBJECT.thisBinaryFilename);
 
       // the check sum auto command hint is always printed,
       // so we just configure with empty string if not present
-      ASSETOBJECT.thisChecksumAutoCommandHint = getChecksumAutoCommandHint(ASSETOBJECT.thisPlatform) || '';
+      ASSETOBJECT.thisChecksumAutoCommandHint = ASSETOBJECT.thisInstallCommands.checksumAutoCommandHint || '';
       // build download sha256 and verify auto command
-      const thisChecksumAutoCommand = getChecksumAutoCommand(ASSETOBJECT.thisPlatform);
+      const thisChecksumAutoCommand = ASSETOBJECT.thisInstallCommands.checksumAutoCommand;
       let sha256FileName = ASSETOBJECT.thisChecksumLink;
       const separator = sha256FileName.lastIndexOf('/');
       if (separator > -1) {
@@ -64,7 +63,7 @@ function buildInstallationHTML(releasesJson) {
       );
 
       const dirName = releasesJson[0].release_name + (eachAsset.image_type === 'jre' ? '-jre' : '');
-      ASSETOBJECT.thisPathCommand = getPathCommand(ASSETOBJECT.thisPlatform).replace('DIRNAME', dirName);
+      ASSETOBJECT.thisPathCommand = ASSETOBJECT.thisInstallCommands.pathCommand.replace('DIRNAME', dirName);
 
       if (ASSETOBJECT.thisPlatformExists) {
         ASSETARRAY.push(ASSETOBJECT);

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -1,5 +1,5 @@
 const {findPlatform, getSupportedVersion, getOfficialName, getPlatformOrder,
-    getVariantObject, detectLTS, detectEA, loadLatestAssets, orderPlatforms, setRadioSelectors, setTickLink} = require('./common');
+  detectLTS, detectEA, loadLatestAssets, orderPlatforms, setRadioSelectors, setTickLink} = require('./common');
 const {jvmVariant, variant} = require('./common');
 
 const loading = document.getElementById('loading');
@@ -25,7 +25,7 @@ module.exports.load = () => {
     return extension
   });
 
-  const LTS = detectLTS(`${variant}-${jvmVariant}`);
+  const LTS = detectLTS(variant);
 
   const styles = `
   .download-last-version:after {
@@ -49,13 +49,6 @@ module.exports.load = () => {
 }
 
 function buildLatestHTML(releasesJson) {
-  // Populate with description
-  const variantObject = getVariantObject(variant + '-' + jvmVariant);
-  if (variantObject.descriptionLink) {
-    document.getElementById('description_header').innerHTML = `What is ${variantObject.description}?`;
-    document.getElementById('description_link').innerHTML = 'Find out here';
-    document.getElementById('description_link').href = variantObject.descriptionLink;
-  }
 
   // Array of releases that have binaries we want to display
   let releases = [];

--- a/src/js/upstream.js
+++ b/src/js/upstream.js
@@ -54,7 +54,7 @@ module.exports.load = () => {
     return extension
   });
 
-  const LTS = detectLTS(`${variant}-${jvmVariant}`);
+  const LTS = detectLTS(variant);
 
   const styles = `
   .download-last-version:after {

--- a/src/json/config.json
+++ b/src/json/config.json
@@ -130,6 +130,32 @@
       "descriptionLink": "https://www.eclipse.org/openj9"
     }
   ],
+  "installCommands": [
+    {
+      "name": "tar",
+      "installCommand": "tar xzf FILENAME",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "sha256sum FILENAME",
+      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
+      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c"
+    },
+    {
+      "name": "gunzip",
+      "installCommand": "gunzip -c FILENAME | tar xf -",
+      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
+      "checksumCommand": "sha256sum FILENAME",
+      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
+      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c"
+    },
+    {
+        "name": "powershell",
+        "installCommand": "Expand-Archive -Path .\\FILENAME -DestinationPath .",
+        "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
+        "checksumCommand": "certutil -hashfile FILENAME SHA256",
+        "checksumAutoCommandHint": " (the command must be run using Command Prompt in the same directory you download the binary file and requires PowerShell 3.0+)",
+        "checksumAutoCommand": "powershell -command \"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;  iwr -outf FILEHASHNAME FILEHASHURL\" && powershell \"$CHECKSUMVAR=($(Get-FileHash -Algorithm SHA256 -LiteralPath FILENAME | Format-List -Property Hash | Out-String) -replace \\\"Hash : \\\", \\\"\\\" -replace \\\"`r`n\\\", \\\"\\\"); Select-String -LiteralPath FILEHASHNAME -Pattern $CHECKSUMVAR | Format-List -Property FileName | Out-String\" | find /i \"FILEHASHNAME\">Nul && ( echo \"FILENAME: The SHA-256 fingerprint matches\" ) || ( echo \"FILENAME: The SHA-256 fingerprint does NOT match\" )"
+    }
+  ],
   "platforms": [
     {
       "officialName": "Linux x64",
@@ -139,11 +165,6 @@
         "os": "linux",
         "architecture": "x64"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "Linux Mint Debian Fedora FreeBSD Gentoo Haiku Kubuntu OpenBSD Red Hat RHEL SuSE Ubuntu Xubuntu hpwOS webOS Tizen",
       "supported_version": {
         "_comment_": "Version numbers use >= logic and need to be specified in ascending order",
@@ -162,11 +183,6 @@
         "os": "alpine-linux",
         "architecture": "x64"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "Alpine Linux 3.5 or later"
     },
@@ -178,11 +194,6 @@
         "os": "linux",
         "architecture": "x64"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": {
         "_comment_": "Version numbers use >= logic and need to be specified in ascending order",
@@ -200,11 +211,6 @@
         "os": "windows",
         "architecture": "x32"
       },
-      "installCommand": "Expand-Archive -Path .\\FILENAME -DestinationPath .",
-      "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
-      "checksumCommand": "certutil -hashfile FILENAME SHA256",
-      "checksumAutoCommandHint": " (the command must be run using Command Prompt in the same directory you download the binary file and requires PowerShell 3.0+)",
-      "checksumAutoCommand": "powershell -command \"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;  iwr -outf FILEHASHNAME FILEHASHURL\" && powershell \"$CHECKSUMVAR=($(Get-FileHash -Algorithm SHA256 -LiteralPath FILENAME | Format-List -Property Hash | Out-String) -replace \\\"Hash : \\\", \\\"\\\" -replace \\\"`r`n\\\", \\\"\\\"); Select-String -LiteralPath FILEHASHNAME -Pattern $CHECKSUMVAR | Format-List -Property FileName | Out-String\" | find /i \"FILEHASHNAME\">Nul && ( echo \"FILENAME: The SHA-256 fingerprint matches\" ) || ( echo \"FILENAME: The SHA-256 fingerprint does NOT match\" )",
       "osDetectionString": "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP",
       "supported_version": "2012r2 or later"
     },
@@ -216,11 +222,6 @@
         "os": "windows",
         "architecture": "x64"
       },
-      "installCommand": "Expand-Archive -Path .\\FILENAME -DestinationPath .",
-      "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
-      "checksumCommand": "certutil -hashfile FILENAME SHA256",
-      "checksumAutoCommandHint": " (the command must be run using Command Prompt in the same directory you download the binary file and requires PowerShell 3.0+)",
-      "checksumAutoCommand": "powershell -command \"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;  iwr -outf FILEHASHNAME FILEHASHURL\" && powershell \"$CHECKSUMVAR=($(Get-FileHash -Algorithm SHA256 -LiteralPath FILENAME | Format-List -Property Hash | Out-String) -replace \\\"Hash : \\\", \\\"\\\" -replace \\\"`r`n\\\", \\\"\\\"); Select-String -LiteralPath FILEHASHNAME -Pattern $CHECKSUMVAR | Format-List -Property FileName | Out-String\" | find /i \"FILEHASHNAME\">Nul && ( echo \"FILENAME: The SHA-256 fingerprint matches\" ) || ( echo \"FILENAME: The SHA-256 fingerprint does NOT match\" )",
       "osDetectionString": "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP",
       "supported_version": "2012r2 or later"
     },
@@ -232,11 +233,6 @@
         "os": "windows",
         "architecture": "aarch64"
       },
-      "installCommand": "Expand-Archive -Path .\\FILENAME -DestinationPath .",
-      "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
-      "checksumCommand": "certutil -hashfile FILENAME SHA256",
-      "checksumAutoCommandHint": " (the command must be run using Command Prompt in the same directory you download the binary file and requires PowerShell 3.0+)",
-      "checksumAutoCommand": "powershell -command \"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;  iwr -outf FILEHASHNAME FILEHASHURL\" && powershell \"$CHECKSUMVAR=($(Get-FileHash -Algorithm SHA256 -LiteralPath FILENAME | Format-List -Property Hash | Out-String) -replace \\\"Hash : \\\", \\\"\\\" -replace \\\"`r`n\\\", \\\"\\\"); Select-String -LiteralPath FILEHASHNAME -Pattern $CHECKSUMVAR | Format-List -Property FileName | Out-String\" | find /i \"FILEHASHNAME\">Nul && ( echo \"FILENAME: The SHA-256 fingerprint matches\" ) || ( echo \"FILENAME: The SHA-256 fingerprint does NOT match\" )",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "2016 or later"
     },
@@ -248,11 +244,6 @@
         "os": "windows",
         "architecture": "x64"
       },
-      "installCommand": "Expand-Archive -Path .\\FILENAME -DestinationPath .",
-      "pathCommand": "set PATH=%cd%\\DIRNAME\\bin;%PATH%",
-      "checksumCommand": "certutil -hashfile FILENAME SHA256",
-      "checksumAutoCommandHint": " (the command must be run using Command Prompt in the same directory you download the binary file and requires PowerShell 3.0+)",
-      "checksumAutoCommand": "powershell -command \"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;  iwr -outf FILEHASHNAME FILEHASHURL\" && powershell \"$CHECKSUMVAR=($(Get-FileHash -Algorithm SHA256 -LiteralPath FILENAME | Format-List -Property Hash | Out-String) -replace \\\"Hash : \\\", \\\"\\\" -replace \\\"`r`n\\\", \\\"\\\"); Select-String -LiteralPath FILEHASHNAME -Pattern $CHECKSUMVAR | Format-List -Property FileName | Out-String\" | find /i \"FILEHASHNAME\">Nul && ( echo \"FILENAME: The SHA-256 fingerprint matches\" ) || ( echo \"FILENAME: The SHA-256 fingerprint does NOT match\" )",
       "osDetectionString": "Windows Win Cygwin Windows Server 2008 R2 / 7 Windows Server 2008 / Vista Windows XP",
       "supported_version": "2012r2 or later"
     },
@@ -264,11 +255,6 @@
         "os": "mac",
         "architecture": "x64"
       },
-      "installCommand": "tar -xf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/Contents/Home/bin:$PATH",
-      "checksumCommand": "shasum -a 256 FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "curl -O -L -s FILEHASHURL && shasum -a 256 -c FILEHASHNAME",
       "osDetectionString": "Mac OS X OSX macOS Macintosh",
       "supported_version": "10.10 or later"
     },
@@ -280,11 +266,6 @@
         "os": "mac",
         "architecture": "x64"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/Contents/Home/bin:$PATH",
-      "checksumCommand": "shasum -a 256 FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "curl -O -L -s FILEHASHURL && shasum -a 256 -c FILEHASHNAME",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "10.10 or later"
     },
@@ -296,11 +277,6 @@
         "os": "linux",
         "architecture": "s390x"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "glibc version 2.17 or higher"
     },
@@ -312,11 +288,6 @@
         "os": "linux",
         "architecture": "s390x"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "glibc version 2.17 or higher"
     },
@@ -328,11 +299,6 @@
         "os": "linux",
         "architecture": "ppc64le"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "glibc version 2.17 or higher"
     },
@@ -344,11 +310,6 @@
         "os": "linux",
         "architecture": "ppc64le"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "glibc version 2.17 or higher"
     },
@@ -360,11 +321,6 @@
         "os": "linux",
         "architecture": "aarch64"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "glibc version 2.17 or higher"
     },
@@ -376,11 +332,6 @@
         "os": "linux",
         "architecture": "aarch64"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "glibc version 2.17 or higher"
     },
@@ -392,11 +343,6 @@
         "os": "linux",
         "architecture": "arm"
       },
-      "installCommand": "tar xzf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "glibc version 2.17 or higher"
     },
@@ -408,11 +354,6 @@
         "os": "solaris",
         "architecture": "sparcv9"
       },
-      "installCommand": "gunzip -c FILENAME | tar xf -",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "solaris 10,11"
     },
@@ -424,11 +365,6 @@
         "os": "solaris",
         "architecture": "x64"
       },
-      "installCommand": "gunzip -c FILENAME | tar xf -",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "solaris 10,11"
     },
@@ -440,11 +376,6 @@
         "os": "aix",
         "architecture": "ppc64"
       },
-      "installCommand": "gunzip -c FILENAME | tar xf -",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "shasum -a 256 FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "curl -O -L FILEHASHURL && shasum -a 256 -c FILEHASHNAME",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "7.1 TL4 or later"
     },
@@ -456,11 +387,6 @@
         "os": "linux",
         "architecture": "riscv64"
       },
-      "installCommand": "tar -xf FILENAME",
-      "pathCommand": "export PATH=$PWD/DIRNAME/bin:$PATH",
-      "checksumCommand": "sha256sum FILENAME",
-      "checksumAutoCommandHint": " (the command must be run on a terminal in the same directory you download the binary file)",
-      "checksumAutoCommand": "wget -O- -q -T 1 -t 1 FILEHASHURL | sha256sum -c",
       "osDetectionString": "not-to-be-detected",
       "supported_version": "glibc version 2.27 or higher"
     }

--- a/src/json/config.json
+++ b/src/json/config.json
@@ -1,133 +1,53 @@
 {
   "variants": [
     {
-      "searchableName": "openjdk8-hotspot",
-      "officialName": "OpenJDK 8 with HotSpot",
-      "jvm": "HotSpot",
+      "searchableName": "openjdk8",
+      "jvm": ["HotSpot", "OpenJ9"],
       "label": "OpenJDK 8",
       "lts": true
     },
     {
-      "searchableName": "openjdk8-openj9",
-      "officialName": "OpenJDK 8 with Eclipse OpenJ9",
-      "description": "Eclipse OpenJ9",
-      "jvm": "OpenJ9",
-      "label": "OpenJDK 8",
-      "lts": true,
-      "descriptionLink": "https://www.eclipse.org/openj9"
-    },
-    {
-      "searchableName": "openjdk9-hotspot",
-      "officialName": "OpenJDK 9 with HotSpot",
-      "jvm": "HotSpot",
+      "searchableName": "openjdk9",
+      "jvm": ["HotSpot", "OpenJ9"],
       "label": "OpenJDK 9",
       "lts": false
     },
     {
-      "searchableName": "openjdk9-openj9",
-      "officialName": "OpenJDK 9 with Eclipse OpenJ9",
-      "description": "Eclipse OpenJ9",
-      "jvm": "OpenJ9",
-      "label": "OpenJDK 9",
-      "lts": false,
-      "descriptionLink": "https://www.eclipse.org/openj9"
-    },
-    {
-      "searchableName": "openjdk10-hotspot",
-      "officialName": "OpenJDK 10 with HotSpot",
-      "jvm": "HotSpot",
+      "searchableName": "openjdk10",
+      "jvm": ["HotSpot", "OpenJ9"],
       "label": "OpenJDK 10",
       "lts": false
     },
     {
-      "searchableName": "openjdk10-openj9",
-      "officialName": "OpenJDK 10 with Eclipse OpenJ9",
-      "description": "Eclipse OpenJ9",
-      "jvm": "OpenJ9",
-      "label": "OpenJDK 10",
-      "lts": false,
-      "descriptionLink": "https://www.eclipse.org/openj9"
-    },
-    {
-      "searchableName": "openjdk11-hotspot",
-      "officialName": "OpenJDK 11 with HotSpot",
-      "jvm": "HotSpot",
+      "searchableName": "openjdk11",
+      "jvm": ["HotSpot", "OpenJ9"],
       "label": "OpenJDK 11",
-      "lts": true,
-      "default": true
+      "default": true,
+      "lts": true
     },
     {
-      "searchableName": "openjdk11-openj9",
-      "officialName": "OpenJDK 11 with Eclipse OpenJ9",
-      "description": "Eclipse OpenJ9",
-      "jvm": "OpenJ9",
-      "label": "OpenJDK 11",
-      "lts": true,
-      "descriptionLink": "https://www.eclipse.org/openj9"
-    },
-    {
-      "searchableName": "openjdk12-hotspot",
-      "officialName": "OpenJDK 12 with HotSpot",
-      "jvm": "HotSpot",
+      "searchableName": "openjdk12",
+      "jvm": ["HotSpot", "OpenJ9"],
       "label": "OpenJDK 12",
       "lts": false
     },
     {
-      "searchableName": "openjdk12-openj9",
-      "officialName": "OpenJDK 12 with Eclipse OpenJ9",
-      "description": "Eclipse OpenJ9",
-      "jvm": "OpenJ9",
-      "label": "OpenJDK 12",
-      "lts": false,
-      "descriptionLink": "https://www.eclipse.org/openj9"
-    },
-    {
-      "searchableName": "openjdk13-hotspot",
-      "officialName": "OpenJDK 13 with HotSpot",
-      "jvm": "HotSpot",
+      "searchableName": "openjdk13",
+      "jvm": ["HotSpot", "OpenJ9"],
       "label": "OpenJDK 13",
       "lts": false
     },
     {
-      "searchableName": "openjdk13-openj9",
-      "officialName": "OpenJDK 13 with Eclipse OpenJ9",
-      "description": "Eclipse OpenJ9",
-      "jvm": "OpenJ9",
-      "label": "OpenJDK 13",
-      "lts": false,
-      "descriptionLink": "https://www.eclipse.org/openj9"
-    },
-    {
-      "searchableName": "openjdk14-hotspot",
-      "officialName": "OpenJDK 14 with HotSpot",
-      "jvm": "HotSpot",
+      "searchableName": "openjdk14",
+      "jvm": ["HotSpot", "OpenJ9"],
       "label": "OpenJDK 14",
       "lts": false
     },
     {
-      "searchableName": "openjdk14-openj9",
-      "officialName": "OpenJDK 14 with Eclipse OpenJ9",
-      "description": "Eclipse OpenJ9",
-      "jvm": "OpenJ9",
-      "label": "OpenJDK 14",
-      "lts": false,
-      "descriptionLink": "https://www.eclipse.org/openj9"
-    },
-    {
-      "searchableName": "openjdk15-hotspot",
-      "officialName": "OpenJDK 15 with HotSpot",
-      "jvm": "HotSpot",
+      "searchableName": "openjdk15",
+      "jvm": ["HotSpot", "OpenJ9"],
       "label": "OpenJDK 15",
       "lts": "latest"
-    },
-    {
-      "searchableName": "openjdk15-openj9",
-      "officialName": "OpenJDK 15 with Eclipse OpenJ9",
-      "description": "Eclipse OpenJ9",
-      "jvm": "OpenJ9",
-      "label": "OpenJDK 15",
-      "lts": "latest",
-      "descriptionLink": "https://www.eclipse.org/openj9"
     }
   ],
   "installCommands": [

--- a/src/json/config.schema.json
+++ b/src/json/config.schema.json
@@ -35,20 +35,19 @@
       "items": {
         "$id": "#/properties/variants/items",
         "type": "object",
-        "required": ["searchableName", "officialName"],
+        "required": ["searchableName"],
         "properties": {
           "searchableName": {
             "$id": "#/properties/variants/items/properties/searchableName",
             "type": "string",
             "title": "Searchable Name (package manager-friendly)",
-            "examples": ["openjdk8-hotspot", "openjdk11-openj9"]
+            "examples": ["openjdk8", "openjdk11"]
           },
-          "officialName": {
-            "$id": "#/properties/variants/items/properties/officialName",
-            "type": "string",
-            "title": "Official name",
-            "description": "Descriptive name that includes OpenJDK and JVM versions.",
-            "examples": ["OpenJDK 8 with HotSpot", "OpenJDK 11 with Eclipse OpenJ9"]
+          "jvm": {
+            "$id": "#/properties/variants/items/properties/jvm",
+            "type": "array",
+            "title": "JVM",
+            "description": "Object containing all supported JVM's for a specific version."
           },
           "default": {
             "$id": "#/properties/variants/items/properties/default",
@@ -56,13 +55,6 @@
             "title": "Default variant",
             "description": "True for a variant that should be selected by default.",
             "default": false
-          },
-          "descriptionLink": {
-            "$id": "#/properties/variants/items/properties/descriptionLink",
-            "type": "string",
-            "format": "uri",
-            "title": "Description link",
-            "examples": ["https://www.eclipse.org/openj9"]
           }
         }
       }

--- a/src/json/config.schema.json
+++ b/src/json/config.schema.json
@@ -4,7 +4,7 @@
   "title": "AdoptOpenJDK Release Definitions",
   "description": "Configuration for product listings on adoptopenjdk.net",
   "type": "object",
-  "required": ["variants", "platforms"],
+  "required": ["variants", "installCommands", "platforms"],
   "definitions": {
     "fileExt": {
       "type": "string",
@@ -67,6 +67,55 @@
         }
       }
     },
+    "installCommands": {
+      "$id": "#/properties/installCommands",
+      "type": "array",
+      "title": "Install Commands",
+      "description": "",
+      "items": {
+        "$id": "#/properties/installCommands/items",
+        "type": "object",
+        "required": [
+          "name",
+          "installCommand",
+          "pathCommand",
+          "checksumCommand",
+          "checksumAutoCommand"
+        ],
+        "properties": {
+          "installCommand": {
+            "$id": "#/properties/installCommands/items/properties/installCommand",
+            "$ref": "#/definitions/command",
+            "title": "Installation command",
+            "examples": ["tar -xf FILENAME"]
+          },
+          "pathCommand": {
+            "$id": "#/properties/installCommands/items/properties/pathCommand",
+            "$ref": "#/definitions/command",
+            "title": "Path command",
+            "examples": ["export PATH=$PWD/DIRNAME/bin:$PATH"]
+          },
+          "checksumCommand": {
+            "$id": "#/properties/installCommands/items/properties/checksumCommand",
+            "$ref": "#/definitions/command",
+            "title": "Checksum command",
+            "examples": ["sha256sum FILENAME"]
+          },
+          "checksumAutoCommandHint": {
+            "$id": "#/properties/installCommands/items/properties/checksumAutoCommandHint",
+            "$ref": "#/definitions/command",
+            "title": "Checksum auto command hint",
+            "examples": ["PowerShell 3.0+ required"]
+          },
+          "checksumAutoCommand": {
+            "$id": "#/properties/installCommands/items/properties/checksumAutoCommand",
+            "$ref": "#/definitions/command",
+            "title": "Checksum auto command",
+            "examples": ["sha256sum FILENAME"]
+          }
+        }
+      }
+    },
     "platforms": {
       "$id": "#/properties/platforms",
       "type": "array",
@@ -78,10 +127,6 @@
         "required": [
           "officialName",
           "searchableName",
-          "installCommand",
-          "pathCommand",
-          "checksumCommand",
-          "checksumAutoCommand",
           "osDetectionString",
           "attributes"
         ],
@@ -101,36 +146,6 @@
             "description": "A string that appears in the FILE NAME of binaries, installers, and checksums, that can be used to identify the platform.",
             "examples": ["X64_LINUX"],
             "pattern": "^(.*)$"
-          },
-          "installCommand": {
-            "$id": "#/properties/platforms/items/properties/installCommand",
-            "$ref": "#/definitions/command",
-            "title": "Installation command",
-            "examples": ["tar -xf FILENAME"]
-          },
-          "pathCommand": {
-            "$id": "#/properties/platforms/items/properties/pathCommand",
-            "$ref": "#/definitions/command",
-            "title": "Path command",
-            "examples": ["export PATH=$PWD/DIRNAME/bin:$PATH"]
-          },
-          "checksumCommand": {
-            "$id": "#/properties/platforms/items/properties/checksumCommand",
-            "$ref": "#/definitions/command",
-            "title": "Checksum command",
-            "examples": ["sha256sum FILENAME"]
-          },
-          "checksumAutoCommandHint": {
-            "$id": "#/properties/platforms/items/properties/checksumAutoCommandHint",
-            "$ref": "#/definitions/command",
-            "title": "Checksum auto command hint",
-            "examples": ["PowerShell 3.0+ required"]
-          },
-          "checksumAutoCommand": {
-            "$id": "#/properties/platforms/items/properties/checksumAutoCommand",
-            "$ref": "#/definitions/command",
-            "title": "Checksum auto command",
-            "examples": ["sha256sum FILENAME"]
           },
           "osDetectionString": {
             "$id": "#/properties/platforms/items/properties/osDetectionString",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)

This PR massively reduces the duplicate data in the config.json today.

Firstly I've pulled out the install commands to a generic object that can be referenced by each platform.

Secondly, I've compressed the variants object to contain avoid needing duplicate variants for each JVM
