### PR TITLE
Replaced append() with appendChild() to fix IE11 incompatibility (fixes #897)

### DIFF
--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -176,7 +176,7 @@ global.populateFilters = (filter) => {
       let option = document.createElement('option');
       option.text = os;
       option.value = os;
-      osFilter.append(option);
+      osFilter.appendChild(option);
     }
     osFilter.value=selected;
   }
@@ -190,7 +190,7 @@ global.populateFilters = (filter) => {
       let option = document.createElement('option');
       option.text = arch;
       option.value = arch;
-      archFilter.append(option)
+      archFilter.appendChild(option)
     }
     archFilter.value=selected;
   }


### PR DESCRIPTION
This PR fixes #897 by replacing `append()` with `appendChild()`. Unfortunately [append doesn't work in all browsers](https://caniuse.com/mdn-api_parentnode_append) and as the code appends a DOM node, `appendChild()` can be used as well.

##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
