### PR TITLE
JMC 8.x snapshot build links

### DIFF
--- a/src/handlebars/jmc.handlebars
+++ b/src/handlebars/jmc.handlebars
@@ -70,6 +70,36 @@
       </tr>
     </table>
 
+    <h2 class="medium-title">Preview JDK Mission Control 8.1.0</h2>
+    <table id="release">
+      <tr>
+        <th>System</th>
+        <th>Version</th>
+        <th>Download</th>
+      </tr>
+      <tr>
+        <td class="first_col">Windows</td>
+        <td>8.1.0 Snapshot</td>
+        <td>
+          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/master/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.1.0-SNAPSHOT-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.0-SNAPSHOT-win32.win32.x86_64.zip</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Mac</td>
+        <td>8.1.0 Snapshot</td>
+        <td>
+          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/master/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.1.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="first_col">Linux</td>
+        <td>8.1.0 Snapshot</td>
+       <td>
+          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/master/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.1.0-SNAPSHOT-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.0-SNAPSHOT-linux.gtk.x86_64.tar.gz</a>
+        </td>
+      </tr>
+    </table>
+
     <br>
     <h3 class="medium-title">Note (MacOS X)</h3>
     <p>Please unpack the archive using: <pre>cat org.openjdk.jmc-7.1.1-macosx.cocoa.x86_64.tar.gz |tar xv -</pre> or <pre>cat org.openjdk.jmc-8.0.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz |tar xv -</pre></p>

--- a/src/handlebars/jmc.handlebars
+++ b/src/handlebars/jmc.handlebars
@@ -51,21 +51,21 @@
         <td class="first_col">Windows</td>
         <td>8.0.0 Snapshot</td>
         <td>
-          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/master/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.0.0-SNAPSHOT-win32.win32.x86_64.zip">org.openjdk.jmc-8.0.0-SNAPSHOT-win32.win32.x86_64.zip</a>
+          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/8.x.x/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.0.0-SNAPSHOT-win32.win32.x86_64.zip">org.openjdk.jmc-8.0.0-SNAPSHOT-win32.win32.x86_64.zip</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Mac</td>
         <td>8.0.0 Snapshot</td>
         <td>
-          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/master/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.0.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.0.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz</a>
+          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/8.x.x/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.0.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.0.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Linux</td>
         <td>8.0.0 Snapshot</td>
        <td>
-          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/master/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.0.0-SNAPSHOT-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.0.0-SNAPSHOT-linux.gtk.x86_64.tar.gz</a>
+          <a href="https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/job/8.x.x/lastSuccessfulBuild/artifact/target/products/org.openjdk.jmc-8.0.0-SNAPSHOT-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.0.0-SNAPSHOT-linux.gtk.x86_64.tar.gz</a>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Hello, I noticed that the JMC snapshot links are outdated. Since master and 8.x.x are distinct jobs, I made distinctive sections as well for 8.1.0 and 8.0.0 builds.

However this PR is slightly incomplete as there's no job for the _tagged_ (RC / GA) jmc releases.

* https://ci.adoptopenjdk.net/view/JMC/job/jmc-build/

* https://github.com/openjdk/jmc/releases/tag/8.0.0-ga


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
