### PR TITLE
Fix date for JDK17 GA in support.html

### DIFF
--- a/src/handlebars/support.handlebars
+++ b/src/handlebars/support.handlebars
@@ -181,7 +181,7 @@
           </td>
           <td>
             jdk-17<br/>
-            19th Sep 2021
+            14th Sep 2021
           </td>
           <td>TBC<sup>[1]</sup></td>
         </tr>


### PR DESCRIPTION
This incorrectly listed a date of the 19th which was the date for the October releases, not the September JDK17 one.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
