### PR TITLE
Fix Semeru Runtimes references on releases page

### DIFF
--- a/src/handlebars/releases.handlebars
+++ b/src/handlebars/releases.handlebars
@@ -84,7 +84,7 @@
                               \{{#if_eq vendor 'adoptium'}}
                               <span class="download-last-version">Temurin*</span>
                               \{{else if_eq vendor 'ibm'}}
-                              <span class="download-last-version">Semeru*</span>
+                              <span class="download-last-version">Semeru Runtimes*</span>
                               \{{else}}
                               <span class="download-last-version">AdoptOpenJDK</span>
                               \{{/if_eq}}
@@ -163,7 +163,7 @@
     
     <span>
       *Temurin releases are provided by the Eclipse Temurin project. Please consume these binaries from <a href="https://adoptium.net">adoptium.net</a> going forwards.</br>
-      *Semuru releases are provided by IBM. Please consume these binaries from <a href="https://developer.ibm.com/languages/java/semeru-runtimes/downloads">developer.ibm.com</a> going forwards.
+      *Semeru Runtimes releases are provided by IBM. Please consume these binaries from <a href="https://developer.ibm.com/languages/java/semeru-runtimes/downloads">developer.ibm.com</a> going forward.
    </span>
 </div>
 


### PR DESCRIPTION
There is a spelling mistake (Semuru) and also the word "Semeru" should really be
"Semeru Runtimes" (which is the correct phrase).

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
