### PR TITLE
Updated website for JMC 8.1.0

### DIFF
--- a/src/handlebars/jmc.handlebars
+++ b/src/handlebars/jmc.handlebars
@@ -40,7 +40,7 @@
 
     <br>
 
-    <h2 class="medium-title">Final JDK Mission Control 7.1.1</h2>
+    <h2 class="medium-title">Final JDK Mission Control 8.1.0</h2>
     <table id="release">
       <tr>
         <th>System</th>
@@ -49,30 +49,30 @@
       </tr>
       <tr>
         <td class="first_col">Windows</td>
-        <td>7.1.1</td>
+        <td>8.1.0</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/7.1.1/org.openjdk.jmc-7.1.1-win32.win32.x86_64.zip">org.openjdk.jmc-7.1.1-win32.win32.x86_64.zip</a>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.0-win32.win32.x86_64.zip</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Mac</td>
-        <td>7.1.1</td>
+        <td>8.1.0</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/7.1.1/org.openjdk.jmc-7.1.1-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-7.1.1-macosx.cocoa.x86_64.tar.gz</a>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Linux</td>
-        <td>7.1.1</td>
+        <td>8.1.0</td>
        <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/7.1.1/org.openjdk.jmc-7.1.1-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-7.1.1-linux.gtk.x86_64.tar.gz</a>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.0-linux.gtk.x86_64.tar.gz</a>
         </td>
       </tr>
     </table>
 
     <br>
 
-    <h2 class="medium-title">Preview JDK Mission Control 8.1.0</h2>
+    <h2 class="medium-title">Preview JDK Mission Control 8.2.0</h2>
     <table id="release">
       <tr>
         <th>System</th>
@@ -81,30 +81,30 @@
       </tr>
       <tr>
         <td class="first_col">Windows</td>
-        <td>8.1.0 Snapshot</td>
+        <td>8.2.0-SNAPSHOT</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0-SNAPSHOT/org.openjdk.jmc-8.1.0-SNAPSHOT-win32.win32.x86_64.zip">org.openjdk.jmc-8.1.0-SNAPSHOT-win32.win32.x86_64.zip</a>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-win32.win32.x86_64.zip">org.openjdk.jmc-8.2.0-SNAPSHOT-win32.win32.x86_64.zip</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Mac</td>
-        <td>8.1.0 Snapshot</td>
+        <td>8.2.0-SNAPSHOT</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0-SNAPSHOT/org.openjdk.jmc-8.1.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.1.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz</a>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz">org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz</a>
         </td>
       </tr>
       <tr>
         <td class="first_col">Linux</td>
-        <td>8.1.0 Snapshot</td>
+        <td>8.2.0-SNAPSHOT</td>
        <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0-SNAPSHOT/org.openjdk.jmc-8.1.0-SNAPSHOT-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.1.0-SNAPSHOT-linux.gtk.x86_64.tar.gz</a>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.2.0-SNAPSHOT/org.openjdk.jmc-8.2.0-SNAPSHOT-linux.gtk.x86_64.tar.gz">org.openjdk.jmc-8.2.0-SNAPSHOT-linux.gtk.x86_64.tar.gz</a>
         </td>
       </tr>
     </table>
 
     <br>
     <h3 class="medium-title" id="macosx-install">Note (MacOS X)</h3>
-    <p>Please unpack the archive using: <pre>cat org.openjdk.jmc-8.0.0-macosx.cocoa.x86_64.tar.gz |tar xv -</pre> or <pre>cat org.openjdk.jmc-8.1.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz |tar xv -</pre></p>
+    <p>Please unpack the archive using: <pre>cat org.openjdk.jmc-8.1.0-macosx.cocoa.x86_64.tar.gz |tar xv -</pre> or <pre>cat org.openjdk.jmc-8.2.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz |tar xv -</pre></p>
 
     <br>
     <p>We also provide an Eclipse update site archive for installing JMC into the Eclipse IDE:</p>
@@ -115,15 +115,9 @@
         <th>Download</th>
       </tr>
       <tr>
-        <td>8.0.0</td>
+        <td>8.1.0</td>
         <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.0.0/org.openjdk.jmc.updatesite.ide-8.0.0.zip">org.openjdk.jmc.updatesite.ide-8.0.0.zip</a>
-        </td>
-      </tr>
-      <tr>
-        <td>7.1.1</td>
-        <td>
-          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/7.1.1/org.openjdk.jmc.updatesite.ide-7.1.1.zip">org.openjdk.jmc.updatesite.ide-7.1.1.zip</a>
+          <a href="https://github.com/AdoptOpenJDK/openjdk-jmc-overrides/releases/download/8.1.0/org.openjdk.jmc.updatesite.ide-8.1.0.zip">org.openjdk.jmc.updatesite.ide-8.1.0.zip</a>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Updated the JMC Website part to include the latest 8.1.0 version

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
