### PR TITLE
Debian repository installation: Keyring should be owned by root

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -369,7 +369,7 @@ rm adoptopenjdk-keyring.gpg
         <li> Save keyring in root directory (Create the keyrings directory)
           <pre>
             <code class="highlighted">
-sudo mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings 
+sudo mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && sudo chown root:root adoptopenjdk-archive-keyring.gpg 
             </code>
           </pre>
         </li>
@@ -454,7 +454,7 @@ rm adoptopenjdk-keyring.gpg
         <li> Save keyring in root directory (Create the keyrings directory)
           <pre>
             <code class="highlighted">
-sudo mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings 
+sudo mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && sudo chown root:root adoptopenjdk-archive-keyring.gpg 
             </code>
           </pre>
         </li>


### PR DESCRIPTION
Make sure the owner of /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg is always root rather than the user who did the Debian repository installation.

As far as I know having the keyring owned by non-root isn't a (realistically exploitable) security problem, since the user who created the keyring is going to be an administrative user, and even then only root the repo is served over HTTPS and only root can change its URL, but better keep things simple and clean.

Fixes: 4eebc787 ("Update on Ubuntu/Debian instruction (#985)")

##### Checklist
- [x] `npm test` passes
- [x] documentation is changed or added (if applicable)
- [X] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
