### PR TITLE
Debian repository installation: Fix path to keyring in chown

### DIFF
--- a/src/handlebars/installation.handlebars
+++ b/src/handlebars/installation.handlebars
@@ -369,7 +369,7 @@ rm adoptopenjdk-keyring.gpg
         <li> Save keyring in root directory (Create the keyrings directory)
           <pre>
             <code class="highlighted">
-sudo mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && sudo chown root:root adoptopenjdk-archive-keyring.gpg 
+sudo mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && sudo chown root:root /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg 
             </code>
           </pre>
         </li>
@@ -454,7 +454,7 @@ rm adoptopenjdk-keyring.gpg
         <li> Save keyring in root directory (Create the keyrings directory)
           <pre>
             <code class="highlighted">
-sudo mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && sudo chown root:root adoptopenjdk-archive-keyring.gpg 
+sudo mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && sudo chown root:root /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg 
             </code>
           </pre>
         </li>


### PR DESCRIPTION
The chown command in #1080 is obviously wrong, as it should be applied to the path of the file after moving, not the one before moving.

##### Checklist
- [X] `npm test` passes
- [X] documentation is changed or added (if applicable)
- [X] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
