### PR TITLE
add further download redirections to home page

### DIFF
--- a/assemble.sh
+++ b/assemble.sh
@@ -1,0 +1,12 @@
+mkdir tmp
+mv sitemap.xml tmp/
+find . -type f ! -name '*.html' ! -name '*.pdf' -maxdepth 1 -mindepth 1  -delete
+find . -type d -not -name 'dist' -not -name '.git' -maxdepth 1 -mindepth 1 -exec rm -rf {} \;
+# After this bulk-delete, copy across some other necessary files from the master branch:
+git checkout main -- NOTICE
+git checkout main -- LICENSE
+cp tmp/sitemap.xml .
+git checkout main -- robots.txt
+git checkout main -- CNAME
+echo "These files are ready to be moved onto the production web server:"
+ls

--- a/assemble.sh
+++ b/assemble.sh
@@ -3,10 +3,10 @@ mv sitemap.xml tmp/
 find . -type f ! -name '*.html' ! -name '*.pdf' -maxdepth 1 -mindepth 1  -delete
 find . -type d -not -name 'dist' -not -name '.git' -maxdepth 1 -mindepth 1 -exec rm -rf {} \;
 # After this bulk-delete, copy across some other necessary files from the master branch:
-git checkout main -- NOTICE
-git checkout main -- LICENSE
+git checkout master -- NOTICE
+git checkout master -- LICENSE
 cp tmp/sitemap.xml .
-git checkout main -- robots.txt
-git checkout main -- CNAME
+git checkout master -- robots.txt
+git checkout master -- CNAME
 echo "These files are ready to be moved onto the production web server:"
 ls

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "gulp",
     "json-validate": "gulp json-validate",
+    "assemble": "bash assemble.sh",
     "lint": "eslint src/**/*.js",
     "lint-fix": "npm run lint --- --fix",
     "test": "npm run lint && npm run json-validate"

--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -46,15 +46,16 @@
 
     <a href="./releases.html" class="dl-button a-button fadeIn invisible" id="dl-latest">
       <div id="dl-version">
-        <i id="dl-icon" class="fa fa-download" aria-hidden="true"></i>
-        <span>Latest release</span>
-        <i id="dl-icon-2" class="fa fa-arrow-circle-o-right hide" aria-hidden="true"></i>
+        <i id="dl-icon" class="fa fa-external-link" aria-hidden="true"></i>
+        <span id="dl-latest-text">Latest release</span>
       </div>
       <div class="dl-description">
         <var id="dl-version-text" class="small-dl-text" release-version></var>
-        <div id="jck-approved-tick" class='tick hide' data-tooltip="This build is JCK certified."><img src='./dist/assets/tick.png' alt="This build is JCK certified."></div>
       </div>
     </a>
+
+    <h4><a href="https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/">AdoptOpenJDK has moved</a>, the blue download button will take you to the new location.</h4>
+    <p>You can stil get AdoptOpenJDK binaries by clicking one of the buttons below:</p>
 
     <a href="./releases.html" class="dl-button dl-thin-button a-button fadeIn invisible" id="dl-other">
       <div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,10 +1,7 @@
 const {
   detectOS,
-  findPlatform,
   loadLatestAssets,
-  makeQueryString,
   setRadioSelectors,
-  setTickLink
 } = require('./common');
 const {
   jvmVariant,
@@ -16,10 +13,9 @@ const loading = document.getElementById('loading');
 const errorContainer = document.getElementById('error-container');
 const dlText = document.getElementById('dl-text');
 const dlLatest = document.getElementById('dl-latest');
+const dlLatestText = document.getElementById('dl-latest-text');
 const dlArchive = document.getElementById('dl-archive');
 const dlOther = document.getElementById('dl-other');
-const dlIcon = document.getElementById('dl-icon');
-const dlIcon2 = document.getElementById('dl-icon-2');
 const dlVersionText = document.getElementById('dl-version-text');
 
 // When index page loads, run:
@@ -35,11 +31,8 @@ module.exports.load = () => {
   }
   dlText.classList.remove('invisible');
 
-  const handleResponse = (releasesJson) => {
-    if (!releasesJson) {
-      return;
-    }
-    buildHomepageHTML(releasesJson, {}, OS);
+  const handleResponse = () => {
+    buildHomepageHTML(jvmVariant);
   };
 
   loadLatestAssets(variant, jvmVariant, 'latest', handleResponse, undefined, () => {
@@ -58,53 +51,15 @@ function removeRadioButtons() {
   }
 }
 
-function buildHomepageHTML(releasesJson, jckJSON, OS) {
-  let matchingFile = null;
-
-  // if the OS has been detected...
-  if (OS) {
-    releasesJson.forEach((eachAsset) => { // iterate through the assets attached to this release
-      const uppercaseFilename = eachAsset.binary.package.name.toUpperCase();
-      const thisPlatform = findPlatform(eachAsset.binary);
-
-      // firstly, check if a valid searchableName has been returned (i.e. the platform is recognised)...
-      if (thisPlatform) {
-        // secondly, check if the file has the expected file extension for that platform...
-        // (this filters out all non-binary attachments, e.g. SHA checksums - these contain the platform name, but are not binaries)
-        if (matchingFile == null) {
-          const uppercaseOSname = OS.searchableName.toUpperCase();
-          if (Object.keys(jckJSON).length !== 0) {
-            if (jckJSON[releasesJson.tag_name] && Object.prototype.hasOwnProperty.call(jckJSON[releasesJson.tag_name], uppercaseOSname)) {
-              document.getElementById('jck-approved-tick').classList.remove('hide');
-              setTickLink();
-            }
-          }
-          // thirdly check if JDK or JRE (we want to serve JDK by default)
-          if (eachAsset.binary.image_type == 'jdk') {
-            // fourthly, check if the user's OS searchableName string matches part of this binary's name (e.g. ...X64_LINUX...)
-            if (uppercaseFilename.includes(uppercaseOSname)) {
-              matchingFile = eachAsset; // set the matchingFile variable to the object containing this binary
-            }
-          }
-        }
-      }
-    });
-  }
-
-  // if there IS a matching binary for the user's OS...
-  if (matchingFile) {
-    if (matchingFile.binary.installer) {
-      dlLatest.href = matchingFile.binary.installer.link; // set the main download button's link to be the installer's download url
-    } else {
-      dlLatest.href = matchingFile.binary.package.link; // set the main download button's link to be the binary's download url
-      dlVersionText.innerHTML += ` - ${Math.floor(matchingFile.binary.package.size / 1000 / 1000)} MB`;
-    }
-    // set the download button's version number to the latest release
-    dlVersionText.innerHTML = matchingFile.release_name;
-  } else {
-    dlIcon.classList.add('hide'); // hide the download icon on the main button, to make it look less like you're going to get a download immediately
-    dlIcon2.classList.remove('hide'); // un-hide an arrow-right icon to show instead
-    dlLatest.href = `./releases.html?${makeQueryString({variant, jvmVariant})}`; // set the main download button's link to the latest releases page for all platforms.
+function buildHomepageHTML(jvmVariant) {
+  if (jvmVariant == 'hotspot') {
+    dlLatest.href = 'https://adoptium.net';
+    dlLatestText.textContent = 'adoptium.net';
+    dlVersionText.innerHTML = 'AdoptOpenJDK has moved...';
+  } else if (jvmVariant == 'openj9') {
+    dlLatest.href = 'https://developer.ibm.com/languages/java/semeru-runtimes/downloads';
+    dlLatestText.textContent = 'developer.ibm.com';
+    dlVersionText.innerHTML = 'AdoptOpenJDK has moved...';
   }
 
   // remove the loading dots, and make all buttons visible, with animated fade-in


### PR DESCRIPTION
This PR overrides the action of the main blue home button to redirect users to either Adoptium or Semuru

Preview Link is https://6154536f87b8dd136f39320b--vibrant-hugle-19d716.netlify.app/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)

![Screenshot 2021-09-29 at 12 23 03](https://user-images.githubusercontent.com/20224954/135259157-44051661-9d55-4f43-b42c-74f20dc8aa62.png)

![Screenshot 2021-09-29 at 12 23 13](https://user-images.githubusercontent.com/20224954/135259188-26a5e24b-75f3-4fa6-94f6-ec9be2ee8e5a.png)


