### PR TITLE
Change banner for upstream binaries.

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -3,12 +3,11 @@
 <main class="grey-bg">
 
   <div id="upstream-page">
-    <h1 class="large-title">OpenJDK Project Builds</h1>
+    <h1 class="large-title">[Discontinued] OpenJDK Project Builds</h1>
 
     <div class="callout upstream-callout">
       <h4 class="bold">What are these binaries?</h4>
-      <p>These binaries are built by Red Hat on their infrastructure on behalf of the OpenJDK jdk8u and jdk11u projects. The binaries are created from the unmodified source code at OpenJDK. Although no formal support agreement is
-provided, please report any bugs you may find to <a href="https://bugs.java.com/">https://bugs.java.com/</a>. If you are looking for the AdoptOpenJDK supported binaries then please find them <a href="./index.html">here</a>.</p>
+      <p>These binaries were built by Red Hat on their infrastructure on behalf of the OpenJDK jdk8u and jdk11u projects. This service has discontinued and the last releases were 8u342 and 11.0.16 (July 2022 CPU update). No more releases will be provided. Please migrate to different binaries. For example <a href="https://adoptium.net/temurin/releases/">Eclipse Temurin</a> JDK 8 and JDK 11 releases.</p>
     </div>
 
     <div style="margin-bottom: 2rem;">


### PR DESCRIPTION
OpenJDK Project Builds will no longer be done for 11 and 8.
July CPU was the final release of this service.

The plan is to redirect to temurin releases going forward (October
timeframe). For now, advise users that no more releases will be
provided.