### PR TITLE
Remove old upstream build access via website

### DIFF
--- a/src/handlebars/upstream.handlebars
+++ b/src/handlebars/upstream.handlebars
@@ -3,107 +3,16 @@
 <main class="grey-bg">
 
   <div id="upstream-page">
-    <h1 class="large-title">[Discontinued] OpenJDK Project Builds</h1>
+    <h1 class="large-title">Discontinued OpenJDK Project Builds</h1>
 
     <div class="callout upstream-callout">
       <h4 class="bold">What are these binaries?</h4>
-      <p>These binaries were built by Red Hat on their infrastructure on behalf of the OpenJDK jdk8u and jdk11u projects. This service has discontinued and the last releases were 8u342 and 11.0.16 (July 2022 CPU update). No more releases will be provided. Please migrate to different binaries. For example <a href="https://adoptium.net/temurin/releases/">Eclipse Temurin</a> JDK 8 and JDK 11 releases.</p>
+      <p>Upstream binaries were built by Red Hat on their infrastructure and distributed by AdoptOpenJDK on behalf of the OpenJDK jdk8u and jdk11u community projects.
+      The last releases produced by this method were 8u342 and 11.0.16 (July 2022 CPU update).
+      This service is now provided by the <a href="https://adoptium.net/">Adoptium</a> project, and users of upstream builds should now migrate to the equivalent
+      <a href="https://adoptium.net/temurin/releases/">Eclipse Temurin</a> releases.</p>
     </div>
 
-    <div style="margin-bottom: 2rem;">
-
-      <div class="btn-container">
-        <form id="jdk-selector" class="btn-form">
-          <h3>1. Choose a Version</h3>
-        </form>
-        <form id="ga-selector" class="btn-form">
-          <h3>2. Choose a release type</h3>
-        <label class="btn-label"><input type="radio" name="ga" value="ga" class="radio-button" lts="true" checked="checked"><span>General Availability (GA)</span></label>
-        <label class="btn-label"><input type="radio" name="ga" value="ea" class="radio-button" lts="true"><span>Early Access (EA)</span></label>
-        </form>
-      </div>
-
-      <div id="loading"><img src="dist/assets/loading_dots.gif" width="40" height="40" alt="Content is loading."></div>
-      <div id="error-container"></div>
-
-    </div>
-
-    <div id="latest-container" class="invisible">
-      <h3 id="description_header"></h3>
-      <a id="description_link" href=""></a>
-      
-      <div class="filter-divs">
-        <div class="filter-os filter-div">
-          <span><strong>Operating System:</strong></span>
-          <select id="os-filter" class="filter" onchange="filterOS()">
-            <option value="Any">-Any-</option>
-          </select>
-        </div>
-
-        <div class="filter-arch filter-div">
-          <span><strong>Architecture:</strong></span>
-          <select id="arch-filter" class="filter" onchange="filterArch()">
-            <option value="Any">-Any-</option>
-          </select>
-        </div>
-      </div>
-
-      <div id="latest-selector">
-        <script id="template-selector" type="text/x-handlebars-template">
-          {{! Create each platform's selector tile }}
-          \{{#each releases}}
-              <table class="main-download__variant__table releases-table">
-                 <tbody>
-                    <tr>
-                       <td class="main-download__variant__name blue-bg">
-                          <span>\{{release_name}}</span>
-                          <span class="download-last-version">OpenJDK</span>
-                          <span><a class="source" href=\{{source}}>Source</a></span>
-                       </td>
-                       <td class="main-download__variant__os">
-                          <span class="os">\{{fetchOS platform_official_name}}</span>
-                          <span>\{{platform_supported_version}}</span>
-                       </td>
-                       <td class="main-download__variant__architecture">
-                          <span class="arch">\{{fetchArch platform_official_name}}</span>
-                       </td>
-                       <td class="main-download__variant__download">
-                          <table class="main-download__variant__sub-table">
-                             <tbody>
-                                <tr class="main-download__variant__sub-table__tr">
-                                   \{{#each binaries}}
-                                <td class="main-download__variant__sub-table__row">
-                                   <table>
-                                      <tbody>
-                                         <tr>
-                                            <td>
-                                               <span class="main-download__variant__download__title"><a href="\{{signature_link}}" class='dark-link'>Signature</a></span>
-                                            </td>
-                                         </tr>
-                                         <tr>
-                                            <td>
-                                               <span>\{{type}} - \{{size}} MB</span>
-                                            </td>
-                                         </tr>
-                                      </tbody>
-                                   </table>
-                                </td>
-                                <td class="main-download__variant__sub-table__row">
-                                   <a class="main-download__variant__sub-table__download" href="\{{link}}"><i class="fa fa-download" aria-hidden="true"></i>&nbsp;\{{fetchExtension link}}</a>
-                                </td>
-                                </tr>
-                                \{{/each}}
-                             </tbody>
-                          </table>
-                       </td>
-                    </tr>
-                 </tbody>
-              </table>
-            \{{/each}}
-          </script>
-         </div>
-      </div>
-    </div>
 </div>
 
 </main>


### PR DESCRIPTION
Remove listing of old upstream builds and clarify where users should now get builds.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] documentation is changed or added (if applicable)
- [ ] permission has been obtained to add new logo (if applicable)
- [ ] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
