### PR TITLE
Fix for Dockerfile smell DL3015

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM ubuntu
 
 RUN \
     apt-get update; \
-    apt-get install -y \
+    apt-get install --no-install-recommends -y \
     build-essential \
     curl; \
     rm -rf /var/lib/apt/lists/*
 
 # setup nodejs
 RUN curl -sL https://deb.nodesource.com/setup_10.x |  bash -
-RUN apt-get install -y nodejs
+RUN apt-get install --no-install-recommends -y nodejs
 
 RUN useradd -ms /bin/bash ubuntu
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3015 occurs when the apt tool is used to install packages without the "--no-install-recommends" flag. This flag is recommended to be used to avoid installing additional packages not explicitly requested.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the "--no-install-recommends" flag is added to the apt-get install command.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
